### PR TITLE
Compatibility for core data models using super entities / sub entities

### DIFF
--- a/Sources/Classes/NSManagedObject+CKRecord.swift
+++ b/Sources/Classes/NSManagedObject+CKRecord.swift
@@ -68,6 +68,19 @@ extension NSManagedObject {
                     } else {
                         ckRecord.setObject(self.value(forKey: attrName) as! Data as CKRecordValue?, forKey: attrName)
                     }
+                case .transformableAttributeType:
+                  if attributeDescription.valueTransformerName == nil {
+                    if let value = self.value(forKey: attrName) as? NSCoding {
+                      let data = NSKeyedArchiver.archivedData(withRootObject: value)
+                      if attributeDescription.allowsExternalBinaryDataStorage {
+                        if let asset = self.createAsset(data: data) {
+                          ckRecord.setObject(asset, forKey:attrName)
+                        }
+                      } else {
+                        ckRecord.setObject(data as CKRecordValue?, forKey: attrName)
+                      }
+                    }
+                  }
                 default:
                     break
                 }

--- a/Sources/Classes/SMStoreChangeSetHandler.swift
+++ b/Sources/Classes/SMStoreChangeSetHandler.swift
@@ -109,8 +109,7 @@ class SMStoreChangeSetHandler {
     func modelForLocalStore(usingModel model: NSManagedObjectModel) -> NSManagedObjectModel {
         let backingModel: NSManagedObjectModel = model.copy() as! NSManagedObjectModel
         for entity in backingModel.entities {
-          let hasSuperEntity = entity.superentity != nil
-          if !hasSuperEntity {
+          if entity.superentity == nil {
             self.addExtraBackingStoreAttributes(toEntity: entity)
           }
         }

--- a/Sources/Classes/SMStoreChangeSetHandler.swift
+++ b/Sources/Classes/SMStoreChangeSetHandler.swift
@@ -109,7 +109,10 @@ class SMStoreChangeSetHandler {
     func modelForLocalStore(usingModel model: NSManagedObjectModel) -> NSManagedObjectModel {
         let backingModel: NSManagedObjectModel = model.copy() as! NSManagedObjectModel
         for entity in backingModel.entities {
+          let hasSuperEntity = entity.superentity != nil
+          if !hasSuperEntity {
             self.addExtraBackingStoreAttributes(toEntity: entity)
+          }
         }
         backingModel.entities.append(self.changeSetEntity())
         return backingModel


### PR DESCRIPTION
Checking for existence of a superentity before adding extra attributes (adding the attributes to both the superentity and its subentities causes errors because the model sees object that has 2 attributes with conflicting -i.e. identical- names)