### PR TITLE
More migration-related changes

### DIFF
--- a/Sources/Classes/CKRecord+NSManagedObject.swift
+++ b/Sources/Classes/CKRecord+NSManagedObject.swift
@@ -90,7 +90,7 @@ extension CKRecord {
                                     let relationshipManagedObject: NSManagedObject = results.last as! NSManagedObject
                                     managedObjectsDictionary[key] = relationshipManagedObject
                                 } else {
-                                    print("No matching related object for \(recordIDString)")
+                                    print("WARNING Missing NON-OPTIONAL related object for '\(entity.name ?? "n/a").\(key)' (missing '\(name)' (\(recordIDString)) )")
                                     context.refresh(managedObject, mergeChanges: false)
                                     throw SMStoreError.missingRelatedObject
                                 }
@@ -123,7 +123,6 @@ extension CKRecord {
                 }
                 
                 try self.setValuesOn(managedObject!, inContext:context)
-                
                 return managedObject
             }
         }
@@ -150,6 +149,7 @@ extension CKRecord {
     let referencesValuesDictionary = try self.allCKReferencesAsManagedObjects(usingContext: context, forManagedObject: managedObject)
     if referencesValuesDictionary != nil {
       for (key,value) in referencesValuesDictionary! {
+        let mo = value as? NSManagedObject
         managedObject.setValue(value, forKey: key)
       }
     }

--- a/Sources/Classes/CKRecord+NSManagedObject.swift
+++ b/Sources/Classes/CKRecord+NSManagedObject.swift
@@ -149,7 +149,6 @@ extension CKRecord {
     let referencesValuesDictionary = try self.allCKReferencesAsManagedObjects(usingContext: context, forManagedObject: managedObject)
     if referencesValuesDictionary != nil {
       for (key,value) in referencesValuesDictionary! {
-        let mo = value as? NSManagedObject
         managedObject.setValue(value, forKey: key)
       }
     }

--- a/Sources/Classes/NSManagedObjectContext+Helpers.swift
+++ b/Sources/Classes/NSManagedObjectContext+Helpers.swift
@@ -33,8 +33,18 @@ import CoreData
 extension NSManagedObjectContext {
     
     func saveIfHasChanges() throws {
+      var err: Error?
         if self.hasChanges {
-            try self.save()
+          performAndWait {
+            do {
+              try self.save()
+            } catch {
+              err = error
+            }
+          }
         }
+      if err != nil {
+        throw err!
+      }
     }
 }

--- a/Sources/Classes/SMObjectDependencyGraph.swift
+++ b/Sources/Classes/SMObjectDependencyGraph.swift
@@ -33,141 +33,142 @@ import CoreData
 import CloudKit
 
 class SMObjectDependencyGraph {
-  private var unsorted: [SMObject]
-  private var ancestorGraph = [String:[[String]]]()
-  private var dependencyGraph: [String:Set<String>] = [:]
-  
-  init(records: [CKRecord], for entities: [NSEntityDescription]) {
-    unsorted = records
-    for r in records {
-      let entityName = r.recordType
-      let entity = entities.first(where: { (entityDesc: NSEntityDescription) -> Bool in
-        entityDesc.name == entityName
-      })
-      if let entity = entity, dependencyGraph[entityName] == nil {
-        dependencyGraph[entityName] = Set<String>()
-        for property in entity.properties {
-          if let relationship = property as? NSRelationshipDescription, !relationship.isToMany {
-            if let destinationName = relationship.destinationEntity?.name {
-              dependencyGraph[entityName]?.insert(destinationName)
+    private var unsorted: [SMObject]
+    private var ancestorGraph = [String:[[String]]]()
+    private var dependencyGraph: [String:Set<String>] = [:]
+    
+    init(records: [CKRecord], for entities: [NSEntityDescription]) {
+        unsorted = records
+        for r in records {
+            let entityName = r.recordType
+            let entity = entities.first(where: { (entityDesc: NSEntityDescription) -> Bool in
+                entityDesc.name == entityName
+            })
+            if let entity = entity, dependencyGraph[entityName] == nil {
+                dependencyGraph[entityName] = Set<String>()
+                for property in entity.properties {
+                    if let relationship = property as? NSRelationshipDescription, !relationship.isToMany {
+                        if let destinationName = relationship.destinationEntity?.name {
+                            dependencyGraph[entityName]?.insert(destinationName)
+                        }
+                    }
+                }
             }
-          }
         }
-      }
-    }
-    
-    for entityName in dependencyGraph.keys {
-      ancestorGraph[entityName] = SMObjectDependencyGraph.recursivelyMakeDependencyChains(chain: [entityName], dependencyGraph: dependencyGraph)
-    }
-  }
-  
-  init(objects: [NSManagedObject]) {
-    unsorted = objects
-    for o in objects {
-      if let entityName = o.entity.name, dependencyGraph[entityName] == nil {
-        dependencyGraph[entityName] = Set<String>()
-        for property in o.entity.properties {
-          if let relationship = property as? NSRelationshipDescription, !property.isOptional {
-            if let destinationName = relationship.destinationEntity?.name {
-              dependencyGraph[entityName]?.insert(destinationName)
-            }
-          }
-        }
-      }
-    }
-    
-    for entityName in dependencyGraph.keys {
-      ancestorGraph[entityName] = SMObjectDependencyGraph.recursivelyMakeDependencyChains(chain: [entityName], dependencyGraph: dependencyGraph)
-    }
-  }
-  
-  var sorted: [Any] {
-    
-    let sortedEntityNames = dependencyGraph.keys.sorted(by: { (entityName1: String, entityName2: String) -> Bool in
-      if let chains1 = ancestorGraph[entityName1], let chains2 = ancestorGraph[entityName2] {
         
-        for chain2 in chains2 {
-          if chain2.contains(entityName1) {
-            // o2 is dependent on o1
-            //print("\(entityName2) depends on \(entityName1)")
-            return true
-          }
+        for entityName in dependencyGraph.keys {
+            ancestorGraph[entityName] = SMObjectDependencyGraph.recursivelyMakeDependencyChains(chain: [entityName], dependencyGraph: dependencyGraph)
         }
-        for chain1 in chains1 {
-          if chain1.contains(entityName2) {
-            // o1 is dependent on o2
-            //print("\(entityName1) depends on \(entityName1)")
+    }
+    
+    init(objects: [NSManagedObject]) {
+        unsorted = objects
+        for o in objects {
+            if let entityName = o.entity.name, dependencyGraph[entityName] == nil {
+                dependencyGraph[entityName] = Set<String>()
+                for property in o.entity.properties {
+                    if let relationship = property as? NSRelationshipDescription, !property.isOptional {
+                        if let destinationName = relationship.destinationEntity?.name {
+                            dependencyGraph[entityName]?.insert(destinationName)
+                        }
+                    }
+                }
+            }
+        }
+        
+        for entityName in dependencyGraph.keys {
+            ancestorGraph[entityName] = SMObjectDependencyGraph.recursivelyMakeDependencyChains(chain: [entityName], dependencyGraph: dependencyGraph)
+        }
+    }
+    
+    var sorted: [Any] {
+        
+        let sortedEntityNames = dependencyGraph.keys.sorted(by: { (entityName1: String, entityName2: String) -> Bool in
+            if let chains1 = ancestorGraph[entityName1], let chains2 = ancestorGraph[entityName2] {
+                
+                for chain2 in chains2 {
+                    if chain2.contains(entityName1) {
+                        // o2 is dependent on o1
+                        //print("\(entityName2) depends on \(entityName1)")
+                        return true
+                    }
+                }
+                for chain1 in chains1 {
+                    if chain1.contains(entityName2) {
+                        // o1 is dependent on o2
+                        //print("\(entityName1) depends on \(entityName1)")
+                        return false
+                    }
+                }
+                
+                // Finally if chains don't intersect, it doesn't really matter as long as we are consistent across chains
+                let root1 = chains1.last!.last!
+                let root2 = chains2.last!.last!
+                return root1 < root2
+            }
+            return false // This should never happen
+        })
+        
+        let results = unsorted.sorted { (o1:SMObject, o2:SMObject) -> Bool in
+            
+            if o2.entityIdentifier == o1.entityIdentifier {
+                // Different instances, same entity: order doesn't matter but we must be consistent across instances (assuming no cycles in dependency chains)
+                return o1.instanceIdentifier < o2.instanceIdentifier
+            }
+            
+            if let index1 = sortedEntityNames.index(of: o1.entityIdentifier), let index2 = sortedEntityNames.index(of: o2.entityIdentifier) {
+                // Same order as entities
+                return index2 > index1
+            }
+            print("WARNING Entity '\(o1.entityIdentifier)' or '\(o2.entityIdentifier)' not referenced in sortedEntityNames (this should never happen)")
             return false
-          }
         }
-        
-        // Finally if chains don't intersect, it doesn't really matter as long as we are consistent across chains
-        let root1 = chains1.last!.last!
-        let root2 = chains2.last!.last!
-        return root1 < root2
-      }
-      return false // This should never happen
-    })
+        return results
+    }
     
-    let results = unsorted.sorted { (o1:SMObject, o2:SMObject) -> Bool in
-      
-      if o2.entityIdentifier == o1.entityIdentifier {
-        // Different instances, same entity: order doesn't matter but we must be consistent across instances (assuming no cycles in dependency chains)
-        return o1.instanceIdentifier < o2.instanceIdentifier
-      }
-      
-      if let index1 = sortedEntityNames.index(of: o1.entityIdentifier), let index2 = sortedEntityNames.index(of: o2.entityIdentifier) {
-        // Same order as entities
-        return index2 > index1
-      }
-      print("WARNING Entity '\(o1.entityIdentifier)' or '\(o2.entityIdentifier)' not referenced in sortedEntityNames (this should never happen)")
-      return false
-    }
-    return results
-  }
-  
-  fileprivate class func recursivelyMakeDependencyChains(chain: [String], dependencyGraph: [String:Set<String>]) -> [[String]] {
-    if let last = chain.last, let dependencies = dependencyGraph[last], dependencies.count > 0 {
-      var chains = [[String]]()
-      for dependency in dependencies {
-        var augmentedChain = chain
-        if chain.contains(dependency) {
-          print("WARNING Loop Detected! Path \(chain) already contains '\(dependency)'")
-          chains.append(chain)
+    fileprivate class func recursivelyMakeDependencyChains(chain: [String], dependencyGraph: [String:Set<String>]) -> [[String]] {
+        if let last = chain.last, let dependencies = dependencyGraph[last], dependencies.count > 0 {
+            var chains = [[String]]()
+            for dependency in dependencies {
+                var augmentedChain = chain
+                if chain.contains(dependency) {
+                    print("WARNING Loop Detected! Path \(chain) already contains '\(dependency)'")
+                    chains.append(chain)
+                } else {
+                    augmentedChain.append(dependency)
+                    for chainFromNextRecursiveIteration in recursivelyMakeDependencyChains(chain: augmentedChain, dependencyGraph: dependencyGraph) {
+                        chains.append(chainFromNextRecursiveIteration)
+                    }
+                }
+            }
+            return chains
         } else {
-          augmentedChain.append(dependency)
-          for chainFromNextRecursiveIteration in recursivelyMakeDependencyChains(chain: augmentedChain, dependencyGraph: dependencyGraph) {
-            chains.append(chainFromNextRecursiveIteration)
-          }
+            return [chain]
         }
-      }
-      return chains
-    } else {
-      return [chain]
     }
-  }
 }
 
 
 protocol SMObject {
-  var entityIdentifier: String {get}
-  var instanceIdentifier: String {get}
+    var entityIdentifier: String {get}
+    var instanceIdentifier: String {get}
 }
 
 extension NSManagedObject: SMObject {
-  var entityIdentifier: String {
-    return entity.name!
-  }
-  var instanceIdentifier: String {
-    return objectID.uriRepresentation().absoluteString
-  }
+    var entityIdentifier: String {
+        return entity.name!
+    }
+    var instanceIdentifier: String {
+        return objectID.uriRepresentation().absoluteString
+    }
 }
 
 extension CKRecord: SMObject {
-  var entityIdentifier: String {
-    return recordType
-  }
-  var instanceIdentifier: String {
-    return recordID.recordName
-  }
+    var entityIdentifier: String {
+        return recordType
+    }
+    var instanceIdentifier: String {
+        return recordID.recordName
+    }
 }
+

--- a/Sources/Classes/SMObjectDependencyGraph.swift
+++ b/Sources/Classes/SMObjectDependencyGraph.swift
@@ -33,140 +33,141 @@ import CoreData
 import CloudKit
 
 class SMObjectDependencyGraph {
-    private var unsorted: [Any]
-    private var ancestorGraph = [String:[[String]]]()
-    private var dependencyGraph: [String:Set<String>] = [:]
-    
-    init(records: [CKRecord], for entities: [NSEntityDescription]) {
-        unsorted = records
-        for r in records {
-            let entityName = r.recordType
-            let entity = entities.first(where: { (entityDesc: NSEntityDescription) -> Bool in
-                entityDesc.name == entityName
-            })
-            if let entity = entity, dependencyGraph[entityName] == nil {
-                dependencyGraph[entityName] = Set<String>()
-                for property in entity.properties {
-                    if let relationship = property as? NSRelationshipDescription, !relationship.isToMany {
-                        if let destinationName = relationship.destinationEntity?.name {
-                            dependencyGraph[entityName]?.insert(destinationName)
-                        }
-                    }
-                }
+  private var unsorted: [SMObject]
+  private var ancestorGraph = [String:[[String]]]()
+  private var dependencyGraph: [String:Set<String>] = [:]
+  
+  init(records: [CKRecord], for entities: [NSEntityDescription]) {
+    unsorted = records
+    for r in records {
+      let entityName = r.recordType
+      let entity = entities.first(where: { (entityDesc: NSEntityDescription) -> Bool in
+        entityDesc.name == entityName
+      })
+      if let entity = entity, dependencyGraph[entityName] == nil {
+        dependencyGraph[entityName] = Set<String>()
+        for property in entity.properties {
+          if let relationship = property as? NSRelationshipDescription, !relationship.isToMany {
+            if let destinationName = relationship.destinationEntity?.name {
+              dependencyGraph[entityName]?.insert(destinationName)
             }
+          }
         }
-        
-        for entityName in dependencyGraph.keys {
-            ancestorGraph[entityName] = SMObjectDependencyGraph.recursivelyMakeDependencyChains(chain: [entityName], dependencyGraph: dependencyGraph)
-        }
+      }
     }
     
-    init(objects: [NSManagedObject]) {
-        unsorted = objects
-        for o in objects {
-            if let entityName = o.entity.name, dependencyGraph[entityName] == nil {
-                dependencyGraph[entityName] = Set<String>()
-                for property in o.entity.properties {
-                    if let relationship = property as? NSRelationshipDescription, !property.isOptional {
-                        if let destinationName = relationship.destinationEntity?.name {
-                            dependencyGraph[entityName]?.insert(destinationName)
-                        }
-                    }
-                }
+    for entityName in dependencyGraph.keys {
+      ancestorGraph[entityName] = SMObjectDependencyGraph.recursivelyMakeDependencyChains(chain: [entityName], dependencyGraph: dependencyGraph)
+    }
+  }
+  
+  init(objects: [NSManagedObject]) {
+    unsorted = objects
+    for o in objects {
+      if let entityName = o.entity.name, dependencyGraph[entityName] == nil {
+        dependencyGraph[entityName] = Set<String>()
+        for property in o.entity.properties {
+          if let relationship = property as? NSRelationshipDescription, !property.isOptional {
+            if let destinationName = relationship.destinationEntity?.name {
+              dependencyGraph[entityName]?.insert(destinationName)
             }
+          }
         }
-        
-        for entityName in dependencyGraph.keys {
-            ancestorGraph[entityName] = SMObjectDependencyGraph.recursivelyMakeDependencyChains(chain: [entityName], dependencyGraph: dependencyGraph)
-        }
+      }
     }
     
-    var sorted: [Any] {
+    for entityName in dependencyGraph.keys {
+      ancestorGraph[entityName] = SMObjectDependencyGraph.recursivelyMakeDependencyChains(chain: [entityName], dependencyGraph: dependencyGraph)
+    }
+  }
+  
+  var sorted: [Any] {
+    
+    let sortedEntityNames = dependencyGraph.keys.sorted(by: { (entityName1: String, entityName2: String) -> Bool in
+      if let chains1 = ancestorGraph[entityName1], let chains2 = ancestorGraph[entityName2] {
         
-        let sortedEntityNames = dependencyGraph.keys.sorted(by: { (entityName1: String, entityName2: String) -> Bool in
-            if let chains1 = ancestorGraph[entityName1], let chains2 = ancestorGraph[entityName2] {
-                
-                for chain2 in chains2 {
-                    if chain2.contains(entityName1) {
-                        // o2 is dependent on o1
-                        print("\(entityName2) depends on \(entityName1)")
-                        return true
-                    }
-                }
-                for chain1 in chains1 {
-                    if chain1.contains(entityName2) {
-                        // o1 is dependent on o2
-                        print("\(entityName1) depends on \(entityName1)")
-                        return false
-                    }
-                }
-                
-                // Finally if chains don't intersect, it doesn't really matter as long as we are consistent across chains
-                let root1 = chains1.last!.last!
-                let root2 = chains2.last!.last!
-                return root1 < root2
-            }
-            return false // This should never happen
-        })
-        
-        let results = unsorted.sorted { (o1:Any, o2:Any) -> Bool in
-            var entityName1: String!
-            var entityName2: String!
-            var instanceIdentifier1: String!
-            var instanceIdentifier2: String!
-            if let mo1 = o1 as? NSManagedObject,  let mo2 = o2 as? NSManagedObject {
-                entityName1 = mo1.entity.name
-                entityName2 = mo2.entity.name
-                instanceIdentifier1 = mo1.objectID.uriRepresentation().absoluteString
-                instanceIdentifier2 = mo2.objectID.uriRepresentation().absoluteString
-            } else if let ro1 = o1 as? CKRecord,  let ro2 = o2 as? CKRecord {
-                entityName1 = ro1.recordType
-                entityName2 = ro2.recordType
-                instanceIdentifier1 = ro1.recordID.recordName
-                instanceIdentifier2 = ro2.recordID.recordName
-            }
-            
-            if entityName2 == entityName1 {
-                // Different instances, same entity: order doesn't matter but we must be consistent across instances (assuming no cycles in dependency chains)
-                return instanceIdentifier1 < instanceIdentifier2
-            }
-            
-            if let index1 = sortedEntityNames.index(of: entityName1), let index2 = sortedEntityNames.index(of: entityName2) {
-                // Same order as entities
-                return index2 > index1
-            }
-            
-            print("WARNING Entity '\(entityName1)' or '\(entityName2)' not referenced in sortedEntityNames (this should never happen)")
+        for chain2 in chains2 {
+          if chain2.contains(entityName1) {
+            // o2 is dependent on o1
+            //print("\(entityName2) depends on \(entityName1)")
+            return true
+          }
+        }
+        for chain1 in chains1 {
+          if chain1.contains(entityName2) {
+            // o1 is dependent on o2
+            //print("\(entityName1) depends on \(entityName1)")
             return false
-            
-            
+          }
         }
-        /*let debugArray = results.map { (object: NSManagedObject) -> String in
-         return object.entity.name ?? "(Entity Has No Name)"
-         }
-         print("OK sorted = \(debugArray)")*/
-        return results
-    }
+        
+        // Finally if chains don't intersect, it doesn't really matter as long as we are consistent across chains
+        let root1 = chains1.last!.last!
+        let root2 = chains2.last!.last!
+        return root1 < root2
+      }
+      return false // This should never happen
+    })
     
-    fileprivate class func recursivelyMakeDependencyChains(chain: [String], dependencyGraph: [String:Set<String>]) -> [[String]] {
-        if let last = chain.last, let dependencies = dependencyGraph[last], dependencies.count > 0 {
-            var chains = [[String]]()
-            for dependency in dependencies {
-                var augmentedChain = chain
-                if chain.contains(dependency) {
-                    print("WARNING Loop Detected! Path \(chain) already contains '\(dependency)'")
-                    chains.append(chain)
-                } else {
-                    augmentedChain.append(dependency)
-                    for chainFromNextRecursiveIteration in recursivelyMakeDependencyChains(chain: augmentedChain, dependencyGraph: dependencyGraph) {
-                        chains.append(chainFromNextRecursiveIteration)
-                    }
-                }
-            }
-            return chains
-        } else {
-            return [chain]
-        }
+    let results = unsorted.sorted { (o1:SMObject, o2:SMObject) -> Bool in
+      
+      if o2.entityIdentifier == o1.entityIdentifier {
+        // Different instances, same entity: order doesn't matter but we must be consistent across instances (assuming no cycles in dependency chains)
+        return o1.instanceIdentifier < o2.instanceIdentifier
+      }
+      
+      if let index1 = sortedEntityNames.index(of: o1.entityIdentifier), let index2 = sortedEntityNames.index(of: o2.entityIdentifier) {
+        // Same order as entities
+        return index2 > index1
+      }
+      print("WARNING Entity '\(o1.entityIdentifier)' or '\(o2.entityIdentifier)' not referenced in sortedEntityNames (this should never happen)")
+      return false
     }
+    return results
+  }
+  
+  fileprivate class func recursivelyMakeDependencyChains(chain: [String], dependencyGraph: [String:Set<String>]) -> [[String]] {
+    if let last = chain.last, let dependencies = dependencyGraph[last], dependencies.count > 0 {
+      var chains = [[String]]()
+      for dependency in dependencies {
+        var augmentedChain = chain
+        if chain.contains(dependency) {
+          print("WARNING Loop Detected! Path \(chain) already contains '\(dependency)'")
+          chains.append(chain)
+        } else {
+          augmentedChain.append(dependency)
+          for chainFromNextRecursiveIteration in recursivelyMakeDependencyChains(chain: augmentedChain, dependencyGraph: dependencyGraph) {
+            chains.append(chainFromNextRecursiveIteration)
+          }
+        }
+      }
+      return chains
+    } else {
+      return [chain]
+    }
+  }
 }
 
+
+protocol SMObject {
+  var entityIdentifier: String {get}
+  var instanceIdentifier: String {get}
+}
+
+extension NSManagedObject: SMObject {
+  var entityIdentifier: String {
+    return entity.name!
+  }
+  var instanceIdentifier: String {
+    return objectID.uriRepresentation().absoluteString
+  }
+}
+
+extension CKRecord: SMObject {
+  var entityIdentifier: String {
+    return recordType
+  }
+  var instanceIdentifier: String {
+    return recordID.recordName
+  }
+}

--- a/Sources/Classes/SMObjectDependencyGraph.swift
+++ b/Sources/Classes/SMObjectDependencyGraph.swift
@@ -6,16 +6,45 @@
 
 import Foundation
 import CoreData
+import CloudKit
 
 class SMObjectDependencyGraph {
-  private var unsorted: [NSManagedObject]
+  private var unsorted: [Any]
   private var ancestorGraph = [String:[[String]]]()
+  //private var sortedEntityNames = [String]()
+  private var dependencyGraph: [String:Set<String>] = [:]
+  
+  init(records: [CKRecord], for entities: [NSEntityDescription]) {
+    unsorted = records
+    //var dependencyGraph: [String:Set<String>] = [:]
+    
+    for r in records {
+      let entityName = r.recordType
+      let entity = entities.first(where: { (entityDesc: NSEntityDescription) -> Bool in
+        entityDesc.name == entityName
+      })
+      if let entity = entity, dependencyGraph[entityName] == nil {
+        dependencyGraph[entityName] = Set<String>()
+        for property in entity.properties {
+          if let relationship = property as? NSRelationshipDescription, !relationship.isToMany {
+            if let destinationName = relationship.destinationEntity?.name {
+              dependencyGraph[entityName]?.insert(destinationName)
+            }
+          }
+        }
+      }
+    }
+    
+    for entityName in dependencyGraph.keys {
+      ancestorGraph[entityName] = SMObjectDependencyGraph.recursivelyMakeDependencyChains(chain: [entityName], dependencyGraph: dependencyGraph)
+    }
+  }
   
   init(objects: [NSManagedObject]) {
     unsorted = objects
-    var dependencyGraph: [String:Set<String>] = [:]
+    //var dependencyGraph: [String:Set<String>] = [:]
     
-    for o in unsorted {
+    for o in objects {
       if let entityName = o.entity.name, dependencyGraph[entityName] == nil {
         dependencyGraph[entityName] = Set<String>()
         for property in o.entity.properties {
@@ -28,74 +57,96 @@ class SMObjectDependencyGraph {
       }
     }
     
-    func recursivelyMakeDependencyChains(chain: [String]) -> [[String]] {
-      if let last = chain.last, let dependencies = dependencyGraph[last], dependencies.count > 0 {
-        var chains = [[String]]()
-        for dependency in dependencies {
-          var augmentedChain = chain
-          if chain.contains(dependency) {
-            print("WARNING Loop Detected! Path \(chain) already contains '\(dependency)'")
-            chains.append(chain)
-          } else {
-            augmentedChain.append(dependency)
-            for chainFromNextRecursiveIteration in recursivelyMakeDependencyChains(chain: augmentedChain) {
-              chains.append(chainFromNextRecursiveIteration)
-            }
-          }
-        }
-        return chains
-      } else {
-        return [chain]
-      }
-    }
-    
-    
     for entityName in dependencyGraph.keys {
-      ancestorGraph[entityName] = recursivelyMakeDependencyChains(chain: [entityName])
+      ancestorGraph[entityName] = SMObjectDependencyGraph.recursivelyMakeDependencyChains(chain: [entityName], dependencyGraph: dependencyGraph)
     }
   }
   
-  var sorted: [NSManagedObject] {
-    let results = unsorted.sorted { (o1:NSManagedObject, o2:NSManagedObject) -> Bool in
-      if let entityName1 = o1.entity.name, let chains1 = ancestorGraph[entityName1] {
-        if let entityName2 = o2.entity.name, let chains2 = ancestorGraph[entityName2] {
-          for chain2 in chains2 {
-            if chain2.contains(entityName1) {
-              // o2 is dependent on o1
-              //print("\(entityName2) depends on \(entityName1)")
-              return true
-            }
+  var sorted: [Any] {
+    
+    let sortedEntityNames = dependencyGraph.keys.sorted(by: { (entityName1: String, entityName2: String) -> Bool in
+      if let chains1 = ancestorGraph[entityName1], let chains2 = ancestorGraph[entityName2] {
+        
+        for chain2 in chains2 {
+          if chain2.contains(entityName1) {
+            // o2 is dependent on o1
+            print("\(entityName2) depends on \(entityName1)")
+            return true
           }
-          for chain1 in chains1 {
-            if chain1.contains(entityName2) {
-              // o1 is dependent on o2
-              //print("\(entityName1) depends on \(entityName1)")
-              return false
-            }
-          }
-          
-          if entityName2 == entityName1 {
-            let identifier1 = o1.objectID.uriRepresentation().absoluteString
-            let identifier2 = o2.objectID.uriRepresentation().absoluteString
-            // Different instances, same entity: order doesn't matter but we must be consistent across instances (assuming no cycles in dependency chains)
-            return identifier1 < identifier2
-          } else {
-            // Different entities, doesn't really matter as long as we are consistent across chains
-            let root1 = chains1.last!.last!
-            let root2 = chains2.last!.last!
-            return root1 < root2
-          }
-        } else {
-          return false      // o1 after o2
         }
-      } else {
-        return true         // o1 before o2
+        for chain1 in chains1 {
+          if chain1.contains(entityName2) {
+            // o1 is dependent on o2
+            print("\(entityName1) depends on \(entityName1)")
+            return false
+          }
+        }
+        
+        // Finally if chains don't intersect, it doesn't really matter as long as we are consistent across chains
+        let root1 = chains1.last!.last!
+        let root2 = chains2.last!.last!
+        return root1 < root2
       }
+      return false // This should never happen
+    })
+    
+    let results = unsorted.sorted { (o1:Any, o2:Any) -> Bool in
+      var entityName1: String!
+      var entityName2: String!
+      var instanceIdentifier1: String!
+      var instanceIdentifier2: String!
+      if let mo1 = o1 as? NSManagedObject,  let mo2 = o2 as? NSManagedObject {
+        entityName1 = mo1.entity.name
+        entityName2 = mo2.entity.name
+        instanceIdentifier1 = mo1.objectID.uriRepresentation().absoluteString
+        instanceIdentifier2 = mo2.objectID.uriRepresentation().absoluteString
+      } else if let ro1 = o1 as? CKRecord,  let ro2 = o2 as? CKRecord {
+        entityName1 = ro1.recordType
+        entityName2 = ro2.recordType
+        instanceIdentifier1 = ro1.recordID.recordName
+        instanceIdentifier2 = ro2.recordID.recordName
+      }
+      
+      if entityName2 == entityName1 {
+        // Different instances, same entity: order doesn't matter but we must be consistent across instances (assuming no cycles in dependency chains)
+        return instanceIdentifier1 < instanceIdentifier2
+      }
+      
+      if let index1 = sortedEntityNames.index(of: entityName1), let index2 = sortedEntityNames.index(of: entityName2) {
+        // Same order as entities
+        return index2 > index1
+      }
+      
+      print("WARNING Entity '\(entityName1)' or '\(entityName2)' not referenced in sortedEntityNames (this should never happen)")
+      return false
+
+      
     }
     /*let debugArray = results.map { (object: NSManagedObject) -> String in
       return object.entity.name ?? "(Entity Has No Name)"
     }
     print("OK sorted = \(debugArray)")*/
     return results
+  }
+  
+  fileprivate class func recursivelyMakeDependencyChains(chain: [String], dependencyGraph: [String:Set<String>]) -> [[String]] {
+    if let last = chain.last, let dependencies = dependencyGraph[last], dependencies.count > 0 {
+      var chains = [[String]]()
+      for dependency in dependencies {
+        var augmentedChain = chain
+        if chain.contains(dependency) {
+          print("WARNING Loop Detected! Path \(chain) already contains '\(dependency)'")
+          chains.append(chain)
+        } else {
+          augmentedChain.append(dependency)
+          for chainFromNextRecursiveIteration in recursivelyMakeDependencyChains(chain: augmentedChain, dependencyGraph: dependencyGraph) {
+            chains.append(chainFromNextRecursiveIteration)
+          }
+        }
+      }
+      return chains
+    } else {
+      return [chain]
+    }
   }
 }

--- a/Sources/Classes/SMObjectDependencyGraph.swift
+++ b/Sources/Classes/SMObjectDependencyGraph.swift
@@ -1,152 +1,172 @@
 //
-//  SMObjectDependencyGraph.swift
+//    SMObjectDependencyGraph.swift
+//    Created by hugo on 9/29/17.
 //
-//  Created by hugo on 9/29/17.
+//    The MIT License (MIT)
 //
+//    Copyright (c) 2016 Paul Wilkinson ( https://github.com/paulw11 )
+//
+//    Based on work by Nofel Mahmood
+//
+//    Portions copyright (c) 2015 Nofel Mahmood ( https://twitter.com/NofelMahmood )
+//
+//    Permission is hereby granted, free of charge, to any person obtaining a copy
+//    of this software and associated documentation files (the "Software"), to deal
+//    in the Software without restriction, including without limitation the rights
+//    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//    copies of the Software, and to permit persons to whom the Software is
+//    furnished to do so, subject to the following conditions:
+//
+//    The above copyright notice and this permission notice shall be included in all
+//    copies or substantial portions of the Software.
+//
+//    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//    SOFTWARE.
 
 import Foundation
 import CoreData
 import CloudKit
 
 class SMObjectDependencyGraph {
-  private var unsorted: [Any]
-  private var ancestorGraph = [String:[[String]]]()
-  //private var sortedEntityNames = [String]()
-  private var dependencyGraph: [String:Set<String>] = [:]
-  
-  init(records: [CKRecord], for entities: [NSEntityDescription]) {
-    unsorted = records
-    //var dependencyGraph: [String:Set<String>] = [:]
+    private var unsorted: [Any]
+    private var ancestorGraph = [String:[[String]]]()
+    private var dependencyGraph: [String:Set<String>] = [:]
     
-    for r in records {
-      let entityName = r.recordType
-      let entity = entities.first(where: { (entityDesc: NSEntityDescription) -> Bool in
-        entityDesc.name == entityName
-      })
-      if let entity = entity, dependencyGraph[entityName] == nil {
-        dependencyGraph[entityName] = Set<String>()
-        for property in entity.properties {
-          if let relationship = property as? NSRelationshipDescription, !relationship.isToMany {
-            if let destinationName = relationship.destinationEntity?.name {
-              dependencyGraph[entityName]?.insert(destinationName)
+    init(records: [CKRecord], for entities: [NSEntityDescription]) {
+        unsorted = records
+        for r in records {
+            let entityName = r.recordType
+            let entity = entities.first(where: { (entityDesc: NSEntityDescription) -> Bool in
+                entityDesc.name == entityName
+            })
+            if let entity = entity, dependencyGraph[entityName] == nil {
+                dependencyGraph[entityName] = Set<String>()
+                for property in entity.properties {
+                    if let relationship = property as? NSRelationshipDescription, !relationship.isToMany {
+                        if let destinationName = relationship.destinationEntity?.name {
+                            dependencyGraph[entityName]?.insert(destinationName)
+                        }
+                    }
+                }
             }
-          }
         }
-      }
-    }
-    
-    for entityName in dependencyGraph.keys {
-      ancestorGraph[entityName] = SMObjectDependencyGraph.recursivelyMakeDependencyChains(chain: [entityName], dependencyGraph: dependencyGraph)
-    }
-  }
-  
-  init(objects: [NSManagedObject]) {
-    unsorted = objects
-    //var dependencyGraph: [String:Set<String>] = [:]
-    
-    for o in objects {
-      if let entityName = o.entity.name, dependencyGraph[entityName] == nil {
-        dependencyGraph[entityName] = Set<String>()
-        for property in o.entity.properties {
-          if let relationship = property as? NSRelationshipDescription, !property.isOptional {
-            if let destinationName = relationship.destinationEntity?.name {
-              dependencyGraph[entityName]?.insert(destinationName)
-            }
-          }
-        }
-      }
-    }
-    
-    for entityName in dependencyGraph.keys {
-      ancestorGraph[entityName] = SMObjectDependencyGraph.recursivelyMakeDependencyChains(chain: [entityName], dependencyGraph: dependencyGraph)
-    }
-  }
-  
-  var sorted: [Any] {
-    
-    let sortedEntityNames = dependencyGraph.keys.sorted(by: { (entityName1: String, entityName2: String) -> Bool in
-      if let chains1 = ancestorGraph[entityName1], let chains2 = ancestorGraph[entityName2] {
         
-        for chain2 in chains2 {
-          if chain2.contains(entityName1) {
-            // o2 is dependent on o1
-            print("\(entityName2) depends on \(entityName1)")
-            return true
-          }
+        for entityName in dependencyGraph.keys {
+            ancestorGraph[entityName] = SMObjectDependencyGraph.recursivelyMakeDependencyChains(chain: [entityName], dependencyGraph: dependencyGraph)
         }
-        for chain1 in chains1 {
-          if chain1.contains(entityName2) {
-            // o1 is dependent on o2
-            print("\(entityName1) depends on \(entityName1)")
+    }
+    
+    init(objects: [NSManagedObject]) {
+        unsorted = objects
+        for o in objects {
+            if let entityName = o.entity.name, dependencyGraph[entityName] == nil {
+                dependencyGraph[entityName] = Set<String>()
+                for property in o.entity.properties {
+                    if let relationship = property as? NSRelationshipDescription, !property.isOptional {
+                        if let destinationName = relationship.destinationEntity?.name {
+                            dependencyGraph[entityName]?.insert(destinationName)
+                        }
+                    }
+                }
+            }
+        }
+        
+        for entityName in dependencyGraph.keys {
+            ancestorGraph[entityName] = SMObjectDependencyGraph.recursivelyMakeDependencyChains(chain: [entityName], dependencyGraph: dependencyGraph)
+        }
+    }
+    
+    var sorted: [Any] {
+        
+        let sortedEntityNames = dependencyGraph.keys.sorted(by: { (entityName1: String, entityName2: String) -> Bool in
+            if let chains1 = ancestorGraph[entityName1], let chains2 = ancestorGraph[entityName2] {
+                
+                for chain2 in chains2 {
+                    if chain2.contains(entityName1) {
+                        // o2 is dependent on o1
+                        print("\(entityName2) depends on \(entityName1)")
+                        return true
+                    }
+                }
+                for chain1 in chains1 {
+                    if chain1.contains(entityName2) {
+                        // o1 is dependent on o2
+                        print("\(entityName1) depends on \(entityName1)")
+                        return false
+                    }
+                }
+                
+                // Finally if chains don't intersect, it doesn't really matter as long as we are consistent across chains
+                let root1 = chains1.last!.last!
+                let root2 = chains2.last!.last!
+                return root1 < root2
+            }
+            return false // This should never happen
+        })
+        
+        let results = unsorted.sorted { (o1:Any, o2:Any) -> Bool in
+            var entityName1: String!
+            var entityName2: String!
+            var instanceIdentifier1: String!
+            var instanceIdentifier2: String!
+            if let mo1 = o1 as? NSManagedObject,  let mo2 = o2 as? NSManagedObject {
+                entityName1 = mo1.entity.name
+                entityName2 = mo2.entity.name
+                instanceIdentifier1 = mo1.objectID.uriRepresentation().absoluteString
+                instanceIdentifier2 = mo2.objectID.uriRepresentation().absoluteString
+            } else if let ro1 = o1 as? CKRecord,  let ro2 = o2 as? CKRecord {
+                entityName1 = ro1.recordType
+                entityName2 = ro2.recordType
+                instanceIdentifier1 = ro1.recordID.recordName
+                instanceIdentifier2 = ro2.recordID.recordName
+            }
+            
+            if entityName2 == entityName1 {
+                // Different instances, same entity: order doesn't matter but we must be consistent across instances (assuming no cycles in dependency chains)
+                return instanceIdentifier1 < instanceIdentifier2
+            }
+            
+            if let index1 = sortedEntityNames.index(of: entityName1), let index2 = sortedEntityNames.index(of: entityName2) {
+                // Same order as entities
+                return index2 > index1
+            }
+            
+            print("WARNING Entity '\(entityName1)' or '\(entityName2)' not referenced in sortedEntityNames (this should never happen)")
             return false
-          }
+            
+            
         }
-        
-        // Finally if chains don't intersect, it doesn't really matter as long as we are consistent across chains
-        let root1 = chains1.last!.last!
-        let root2 = chains2.last!.last!
-        return root1 < root2
-      }
-      return false // This should never happen
-    })
+        /*let debugArray = results.map { (object: NSManagedObject) -> String in
+         return object.entity.name ?? "(Entity Has No Name)"
+         }
+         print("OK sorted = \(debugArray)")*/
+        return results
+    }
     
-    let results = unsorted.sorted { (o1:Any, o2:Any) -> Bool in
-      var entityName1: String!
-      var entityName2: String!
-      var instanceIdentifier1: String!
-      var instanceIdentifier2: String!
-      if let mo1 = o1 as? NSManagedObject,  let mo2 = o2 as? NSManagedObject {
-        entityName1 = mo1.entity.name
-        entityName2 = mo2.entity.name
-        instanceIdentifier1 = mo1.objectID.uriRepresentation().absoluteString
-        instanceIdentifier2 = mo2.objectID.uriRepresentation().absoluteString
-      } else if let ro1 = o1 as? CKRecord,  let ro2 = o2 as? CKRecord {
-        entityName1 = ro1.recordType
-        entityName2 = ro2.recordType
-        instanceIdentifier1 = ro1.recordID.recordName
-        instanceIdentifier2 = ro2.recordID.recordName
-      }
-      
-      if entityName2 == entityName1 {
-        // Different instances, same entity: order doesn't matter but we must be consistent across instances (assuming no cycles in dependency chains)
-        return instanceIdentifier1 < instanceIdentifier2
-      }
-      
-      if let index1 = sortedEntityNames.index(of: entityName1), let index2 = sortedEntityNames.index(of: entityName2) {
-        // Same order as entities
-        return index2 > index1
-      }
-      
-      print("WARNING Entity '\(entityName1)' or '\(entityName2)' not referenced in sortedEntityNames (this should never happen)")
-      return false
-
-      
-    }
-    /*let debugArray = results.map { (object: NSManagedObject) -> String in
-      return object.entity.name ?? "(Entity Has No Name)"
-    }
-    print("OK sorted = \(debugArray)")*/
-    return results
-  }
-  
-  fileprivate class func recursivelyMakeDependencyChains(chain: [String], dependencyGraph: [String:Set<String>]) -> [[String]] {
-    if let last = chain.last, let dependencies = dependencyGraph[last], dependencies.count > 0 {
-      var chains = [[String]]()
-      for dependency in dependencies {
-        var augmentedChain = chain
-        if chain.contains(dependency) {
-          print("WARNING Loop Detected! Path \(chain) already contains '\(dependency)'")
-          chains.append(chain)
+    fileprivate class func recursivelyMakeDependencyChains(chain: [String], dependencyGraph: [String:Set<String>]) -> [[String]] {
+        if let last = chain.last, let dependencies = dependencyGraph[last], dependencies.count > 0 {
+            var chains = [[String]]()
+            for dependency in dependencies {
+                var augmentedChain = chain
+                if chain.contains(dependency) {
+                    print("WARNING Loop Detected! Path \(chain) already contains '\(dependency)'")
+                    chains.append(chain)
+                } else {
+                    augmentedChain.append(dependency)
+                    for chainFromNextRecursiveIteration in recursivelyMakeDependencyChains(chain: augmentedChain, dependencyGraph: dependencyGraph) {
+                        chains.append(chainFromNextRecursiveIteration)
+                    }
+                }
+            }
+            return chains
         } else {
-          augmentedChain.append(dependency)
-          for chainFromNextRecursiveIteration in recursivelyMakeDependencyChains(chain: augmentedChain, dependencyGraph: dependencyGraph) {
-            chains.append(chainFromNextRecursiveIteration)
-          }
+            return [chain]
         }
-      }
-      return chains
-    } else {
-      return [chain]
     }
-  }
 }
+

--- a/Sources/Classes/SMServerStoreSetupOperation.swift
+++ b/Sources/Classes/SMServerStoreSetupOperation.swift
@@ -50,7 +50,13 @@ class SMServerStoreSetupOperation:Operation {
         let defaults = UserDefaults.standard
         
         let fetchRecordZonesOperation = CKFetchRecordZonesOperation(recordZoneIDs: [zone.zoneID])
-        
+        if #available(iOS 11.0, *) {
+          let config = CKOperationConfiguration()
+          config.timeoutIntervalForResource = 10.0
+          fetchRecordZonesOperation.configuration = config
+        } else if #available(iOS 10.0, *) {
+          fetchRecordZonesOperation.timeoutIntervalForResource = 10.0
+        }
         fetchRecordZonesOperation.database = self.database
         
         fetchRecordZonesOperation.fetchRecordZonesCompletionBlock = ({(zones,operationError) -> Void in

--- a/Sources/Classes/SMServerZoneLookupOperation.swift
+++ b/Sources/Classes/SMServerZoneLookupOperation.swift
@@ -1,10 +1,32 @@
 //
-//  SMServerStoreLookupOperation.swift
-//  Seam3_Example
+//    SMServerStoreLookupOperation.swift
+//    Created by hugo on 10/5/17.
 //
-//  Created by hugo on 10/5/17.
-//  Copyright © 2017 CocoaPods. All rights reserved.
+//    The MIT License (MIT)
 //
+//    Copyright (c) 2016 Paul Wilkinson ( https://github.com/paulw11 )
+//
+//    Based on work by Nofel Mahmood
+//
+//    Portions copyright (c) 2015 Nofel Mahmood ( https://twitter.com/NofelMahmood )
+//
+//    Permission is hereby granted, free of charge, to any person obtaining a copy
+//    of this software and associated documentation files (the "Software"), to deal
+//    in the Software without restriction, including without limitation the rights
+//    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//    copies of the Software, and to permit persons to whom the Software is
+//    furnished to do so, subject to the following conditions:
+//
+//    The above copyright notice and this permission notice shall be included in all
+//    copies or substantial portions of the Software.
+//
+//    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//    SOFTWARE.
 
 import Foundation
 import CloudKit

--- a/Sources/Classes/SMServerZoneLookupOperation.swift
+++ b/Sources/Classes/SMServerZoneLookupOperation.swift
@@ -1,0 +1,53 @@
+//
+//  SMServerStoreLookupOperation.swift
+//  Seam3_Example
+//
+//  Created by hugo on 10/5/17.
+//  Copyright © 2017 CocoaPods. All rights reserved.
+//
+
+import Foundation
+import CloudKit
+
+class SMServerZoneLookupOperation:Operation {
+  
+  var database:CKDatabase?
+  var lookupOperationCompletionBlock:((_ customZoneExists:Bool,_ error: Error?)->Void)?
+  
+  init(cloudDatabase:CKDatabase?) {
+    self.database = cloudDatabase
+    super.init()
+  }
+  
+  override func main() {
+    
+    let zone = CKRecordZone(zoneName: SMStore.SMStoreCloudStoreCustomZoneName)
+    var error: Error?
+    var customZoneExists = false
+    let operationQueue = OperationQueue()
+    let fetchRecordZonesOperation = CKFetchRecordZonesOperation(recordZoneIDs: [zone.zoneID])
+    
+    fetchRecordZonesOperation.database = self.database
+    
+    fetchRecordZonesOperation.fetchRecordZonesCompletionBlock = ({(zones,operationError) -> Void in
+      
+      error = operationError
+      var ckError = operationError as? CKError
+      
+      if ckError?.partialErrorsByItemID != nil {
+        ckError = ckError?.partialErrorsByItemID?.values.first as? CKError
+      }
+      
+      customZoneExists = (ckError?.code != .zoneNotFound)
+      if ckError?.code == .zoneNotFound {
+        error = nil
+      }
+    })
+    
+    operationQueue.addOperation(fetchRecordZonesOperation)
+    operationQueue.waitUntilAllOperationsAreFinished()
+    if let completion = self.lookupOperationCompletionBlock {
+      completion(customZoneExists, error)
+    }
+  }
+}

--- a/Sources/Classes/SMStore.swift
+++ b/Sources/Classes/SMStore.swift
@@ -173,40 +173,40 @@ import CloudKit
 import ObjectiveC
 
 public struct SMStoreNotification {
-  public static let SyncDidStart = "SMStoreDidStartSyncOperationNotification"
-  public static let SyncDidFinish = "SMStoreDidFinishSyncOperationNotification"
+    public static let SyncDidStart = "SMStoreDidStartSyncOperationNotification"
+    public static let SyncDidFinish = "SMStoreDidFinishSyncOperationNotification"
 }
 
 /// Potential errors from SMStore operations
 enum SMStoreError: Error {
-  /// Error occurred executing a Core Data fetch request against the backing store
-  case backingStoreFetchRequestError
-  /// Invalid request
-  case invalidRequest
-  /// Error occurred creating the backing store
-  case backingStoreCreationFailed
-  /// Error occurred resetting the backing store
-  case backingStoreResetFailed
-  /// Error occurred updating the backing store
-  case backingStoreUpdateError
-  /// A relationship in the Core Data model is missing the required inverse relationship
-  case missingInverseRelationship
-  //// "To-many" relationships are not supported
-  case manyToManyUnsupported
-  /// The related object could not be found to satisfy a relationship
-  case missingRelatedObject
-  /// More than one match was found for a 'to-one' relationship
-  case tooManyRelatedObjects
+    /// Error occurred executing a Core Data fetch request against the backing store
+    case backingStoreFetchRequestError
+    /// Invalid request
+    case invalidRequest
+    /// Error occurred creating the backing store
+    case backingStoreCreationFailed
+    /// Error occurred resetting the backing store
+    case backingStoreResetFailed
+    /// Error occurred updating the backing store
+    case backingStoreUpdateError
+    /// A relationship in the Core Data model is missing the required inverse relationship
+    case missingInverseRelationship
+    //// "To-many" relationships are not supported
+    case manyToManyUnsupported
+    /// The related object could not be found to satisfy a relationship
+    case missingRelatedObject
+    /// More than one match was found for a 'to-one' relationship
+    case tooManyRelatedObjects
 }
 
 /// Sync conflict resolution policies
 public enum SMSyncConflictResolutionPolicy: Int16 {
-  /// Client determines sync winner using resolution closure
-  case clientTellsWhichWins = 0
-  /// Server record always wins
-  case serverRecordWins = 1
-  /// Client record always wins
-  case clientRecordWins = 2
+    /// Client determines sync winner using resolution closure
+    case clientTellsWhichWins = 0
+    /// Server record always wins
+    case serverRecordWins = 1
+    /// Client record always wins
+    case clientRecordWins = 2
 }
 
 
@@ -216,706 +216,698 @@ public enum SMSyncConflictResolutionPolicy: Int16 {
  */
 
 open class SMStore: NSIncrementalStore {
-  
-  /// Default value of `syncAutomatically` assigned to new `SMStore` instances.
-  /// Defaults to `true`
-  public static var syncAutomatically: Bool = true
-  
-  /// If true, a sync is triggered automatically when a save operation is performed against the store. Defaults to `true`
-  public var syncAutomatically: Bool = SMStore.syncAutomatically
-  
-  public typealias SMStoreConflictResolutionBlock = (_ clientRecord:CKRecord,_ serverRecord:CKRecord, _ ancestorRecord:CKRecord )->CKRecord
-  
-  /// The closure that will be invoked to resolve sync conflicts when the `SMStoreSyncConflictResolutionPolicyOption` is set to `clientTellsWhichWins`
-  /// - parameter clientRecord:   a `CKRecord` representing the client record state
-  /// - parameter serverRecord:   a `CKRecord` representing the server (cloud) record state
-  /// - returns: The record that will be saved to both the client and cloud
-  public var recordConflictResolutionBlock: SMStoreConflictResolutionBlock?
-  
-  public static let SMStoreSyncConflictResolutionPolicyOption = "SMStoreSyncConflictResolutionPolicyOption"
-  public static let SMStoreErrorDomain = "SMStoreErrorDomain"
-  
-  /**
-   The default Cloud Kit container is named using your app or application's *bundle identifier*.  If you want to share Cloud Kit data between apps on different platforms (e.g. iOS and macOS) then you need to use a named Cloud Kit container.  You can specify a cloud kit container when you create your SMStore instance.
-   
-   On iOS10, specify the `SMStore.SMStoreContainerOption` using the `NSPersistentStoreDescription` object
-   
-   ```
-   let storeDescription = NSPersistentStoreDescription(url: url)
-   storeDescription.type = SMStore.type
-   storeDescription.setOption("iCloud.org.cocoapods.demo.Seam3-Example" as NSString, forKey: SMStore.SMStoreContainerOption)
-   ```
-   
-   On iOS9 and macOS specify an options dictionary to the persistent store coordinator
-   
-   ```
-   let options:[String:Any] = [SMStore.SMStoreContainerOption:"iCloud.org.cocoapods.demo.Seam3-Example"]
-   self.smStore = try coordinator!.addPersistentStore(ofType: SMStore.type, configurationName: nil, at: url, options: options) as? SMStore
-   ```
-   */
-  public static let SMStoreContainerOption = "SMStoreContainerOption"
-  
-  static let SMStoreCloudStoreCustomZoneName = "SMStoreCloudStore_CustomZone"
-  static let SMStoreCloudStoreSubscriptionName = "SM_CloudStore_Subscription"
-  static let SMLocalStoreRecordIDAttributeName="sm_LocalStore_RecordID"
-  static let SMLocalStoreRecordChangedPropertiesAttributeName = "sm_LocalStore_ChangedProperties"
-  static let SMLocalStoreRecordEncodedValuesAttributeName = "sm_LocalStore_EncodedValues"
-  static let SMLocalStoreChangeSetEntityName = "SM_LocalStore_ChangeSetEntity"
-  
-  fileprivate var syncOperation: SMStoreSyncOperation?
-  fileprivate var cloudStoreSetupOperation: SMServerStoreSetupOperation?
-  fileprivate var cksStoresSyncConflictPolicy: SMSyncConflictResolutionPolicy = SMSyncConflictResolutionPolicy.serverRecordWins
-  fileprivate var database: CKDatabase?
-  fileprivate var operationQueue: OperationQueue?
-  fileprivate var backingPersistentStoreCoordinator: NSPersistentStoreCoordinator?
-  fileprivate var backingPersistentStore: NSPersistentStore?
-  fileprivate var ckContainer: CKContainer?
-  
-  fileprivate var automaticStoreMigration = false
-  fileprivate var inferMappingModel = false
-  
-  fileprivate var cloudKitValid = false
-  
-  fileprivate lazy var backingMOC: NSManagedObjectContext = {
-    var moc = NSManagedObjectContext(concurrencyType: NSManagedObjectContextConcurrencyType.privateQueueConcurrencyType)
-    moc.persistentStoreCoordinator = self.backingPersistentStoreCoordinator
-    moc.retainsRegisteredObjects = true
-    moc.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy
-    return moc     }()
-  
-  fileprivate static var storeRegistered = false
-  
-  /// Initialize this store
-  /// -SeeAlso: `NSIncrementalStore.initialize`
-  /*  override open class func initialize() {
-   NSPersistentStoreCoordinator.registerStoreClass(self, forStoreType: self.type)
-   }*/
-  
-  /**
-   You must call this function to register the SMStore class before attempting
-   to create a store
-   */
-  
-  public class func registerStoreClass() {
-    if !storeRegistered {
-      NSPersistentStoreCoordinator.registerStoreClass(self, forStoreType: self.type)
-      storeRegistered = true
-    }
-  }
-  
-  /// Returns a store initialized with the given arguments
-  /// - parameter persistentStoreCoordinator: A persistent store coordinator
-  /// - parameter configurationName: The name of the managed object model configuration to use. Pass nil if you do not want to specify a configuration.
-  /// - parameter url: The URL of the store to load.
-  /// - parameter options: A dictionary containing configuration options. See `NSPersistentStoreCoordinator` for a list of key names for options in this dictionary. `SMStoreSyncConflictResolutionPolicyOption` can also be specified in this dictionary.  `SMStoreContainerOption` can be used to specify a specific cloudkit container
-  /// - returns: A new store object, associated with coordinator, that represents a persistent store at url using the options in options and—if it is not nil—the managed object model configuration configurationName.
-  
-  override init(persistentStoreCoordinator root: NSPersistentStoreCoordinator?, configurationName name: String?, at url: URL, options: [AnyHashable: Any]?) {
     
-    if let opts = options {
-      
-      if let containerIdentifier = opts[SMStore.SMStoreContainerOption] as? String {
-        self.ckContainer = CKContainer(identifier: containerIdentifier)
-      }
-      
-      if let syncConflictPolicyRawValue = opts[SMStore.SMStoreSyncConflictResolutionPolicyOption] as? NSNumber {
-        if let syncConflictPolicy = SMSyncConflictResolutionPolicy(rawValue: syncConflictPolicyRawValue.int16Value) {
-          self.cksStoresSyncConflictPolicy = syncConflictPolicy
-        }
-      }
-      
-      if let migrationPolicy = opts[NSMigratePersistentStoresAutomaticallyOption] as? Bool {
-        self.automaticStoreMigration = migrationPolicy
-      }
-      
-      if let inferMapping = opts[NSInferMappingModelAutomaticallyOption] as? Bool {
-        self.inferMappingModel = inferMapping
-      }
-      
-    }
+    /// Default value of `syncAutomatically` assigned to new `SMStore` instances.
+    /// Defaults to `true`
+    public static var syncAutomatically: Bool = true
     
-    if self.ckContainer == nil {
-      self.ckContainer = CKContainer.default()
-    }
+    /// If true, a sync is triggered automatically when a save operation is performed against the store. Defaults to `true`
+    public var syncAutomatically: Bool = SMStore.syncAutomatically
     
-    self.database = self.ckContainer!.privateCloudDatabase
+    public typealias SMStoreConflictResolutionBlock = (_ clientRecord:CKRecord,_ serverRecord:CKRecord, _ ancestorRecord:CKRecord )->CKRecord
     
-    super.init(persistentStoreCoordinator: root, configurationName: name, at: url, options: options)
-  }
-  
-  /// The type string of the receiver. (`SMStore`)
-  
-  class open var type:String {
-    return NSStringFromClass(self)
-  }
-  
-  
-  /// Instructs the receiver to load its metadata.
-  /// - returns: `true` if the metadata was loaded correctly, otherwise `false`.
-  /// - throws: An `SMStoreError` if the backing store could not be created
-  
-  override open func loadMetadata() throws {
-    self.metadata=[
-      NSStoreUUIDKey: "A9909604-1EF0-4049-BD7F-2CF6AE3D3A6D",
-      NSStoreTypeKey: Swift.type(of: self).type
-    ]
+    /// The closure that will be invoked to resolve sync conflicts when the `SMStoreSyncConflictResolutionPolicyOption` is set to `clientTellsWhichWins`
+    /// - parameter clientRecord:   a `CKRecord` representing the client record state
+    /// - parameter serverRecord:   a `CKRecord` representing the server (cloud) record state
+    /// - returns: The record that will be saved to both the client and cloud
+    public var recordConflictResolutionBlock: SMStoreConflictResolutionBlock?
     
-    try self.createBackingStore()
-  }
-  
-  /// Reset the backing store.  This function should be called where the local store should be cleared prior to a re-sync from the cloud.  E.g. Where a change in CloudKit user has been identified.
-  /// - throws: An `SMStoreError` if the backing store could not be reset
-  public func resetBackingStore() throws {
+    public static let SMStoreSyncConflictResolutionPolicyOption = "SMStoreSyncConflictResolutionPolicyOption"
+    public static let SMStoreErrorDomain = "SMStoreErrorDomain"
     
-    guard let backingMOM = self.backingModel() else {
-      throw SMStoreError.backingStoreResetFailed
-    }
+    /**
+     The default Cloud Kit container is named using your app or application's *bundle identifier*.  If you want to share Cloud Kit data between apps on different platforms (e.g. iOS and macOS) then you need to use a named Cloud Kit container.  You can specify a cloud kit container when you create your SMStore instance.
+     
+     On iOS10, specify the `SMStore.SMStoreContainerOption` using the `NSPersistentStoreDescription` object
+     
+     ```
+     let storeDescription = NSPersistentStoreDescription(url: url)
+     storeDescription.type = SMStore.type
+     storeDescription.setOption("iCloud.org.cocoapods.demo.Seam3-Example" as NSString, forKey: SMStore.SMStoreContainerOption)
+     ```
+     
+     On iOS9 and macOS specify an options dictionary to the persistent store coordinator
+     
+     ```
+     let options:[String:Any] = [SMStore.SMStoreContainerOption:"iCloud.org.cocoapods.demo.Seam3-Example"]
+     self.smStore = try coordinator!.addPersistentStore(ofType: SMStore.type, configurationName: nil, at: url, options: options) as? SMStore
+     ```
+     */
+    public static let SMStoreContainerOption = "SMStoreContainerOption"
     
-    for entity in backingMOM.entities {
-      let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: entity.name!)
-      let deleteRequest = NSBatchDeleteRequest(fetchRequest: fetchRequest)
-      
-      try self.backingMOC.execute(deleteRequest)
-      
-    }
+    static let SMStoreCloudStoreCustomZoneName = "SMStoreCloudStore_CustomZone"
+    static let SMStoreCloudStoreSubscriptionName = "SM_CloudStore_Subscription"
+    static let SMLocalStoreRecordIDAttributeName="sm_LocalStore_RecordID"
+    static let SMLocalStoreRecordChangedPropertiesAttributeName = "sm_LocalStore_ChangedProperties"
+    static let SMLocalStoreRecordEncodedValuesAttributeName = "sm_LocalStore_EncodedValues"
+    static let SMLocalStoreChangeSetEntityName = "SM_LocalStore_ChangeSetEntity"
     
+    fileprivate var syncOperation: SMStoreSyncOperation?
+    fileprivate var cloudStoreSetupOperation: SMServerStoreSetupOperation?
+    fileprivate var cksStoresSyncConflictPolicy: SMSyncConflictResolutionPolicy = SMSyncConflictResolutionPolicy.serverRecordWins
+    fileprivate var database: CKDatabase?
+    fileprivate var operationQueue: OperationQueue?
+    fileprivate var backingPersistentStoreCoordinator: NSPersistentStoreCoordinator?
+    fileprivate var backingPersistentStore: NSPersistentStore?
+    fileprivate var ckContainer: CKContainer?
     
-    let defaults = UserDefaults.standard
+    fileprivate var automaticStoreMigration = false
+    fileprivate var inferMappingModel = false
     
-    defaults.set(false, forKey:SMStore.SMStoreCloudStoreCustomZoneName)
+    fileprivate var cloudKitValid = false
     
-    defaults.set(false, forKey:SMStore.SMStoreCloudStoreSubscriptionName)
-  }
-  
-  /// Retrieve an `NSPredicate` that will match the supplied `NSManagedObject`.
-  /// - parameter for: The name of the relationship that holds the reference to the target object
-  /// - parameter object: The related `NSManagedObject` to search for
-  /// - returns: An `NSPredicate` that will retrieve the supplied object.
-  
-  public func predicate(for relationship: String, referencing object: NSManagedObject) -> NSPredicate {
-    let recordID = self.referenceObject(for: object.objectID)
+    fileprivate lazy var backingMOC: NSManagedObjectContext = {
+        var moc = NSManagedObjectContext(concurrencyType: NSManagedObjectContextConcurrencyType.privateQueueConcurrencyType)
+        moc.persistentStoreCoordinator = self.backingPersistentStoreCoordinator
+        moc.retainsRegisteredObjects = true
+        moc.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy
+        return moc     }()
     
-    let predicateObjectRecordIDKey = "objectRecordID"
-    let predicate: NSPredicate = NSPredicate(format: "%K == $objectRecordID", "\(relationship).sm_LocalStore_RecordID")
+    fileprivate static var storeRegistered = false
     
-    return predicate.withSubstitutionVariables([predicateObjectRecordIDKey: recordID])
-  }
-  
-  /// Retrieve an `NSPredicate` that will match the supplied `NSManagedObject` in a to-many.
-  /// - parameter forToMany: The name of the to-many relationship that holds the reference to the target object
-  /// - parameter object: The related `NSManagedObject` to search for
-  /// - returns: An `NSPredicate` that will retrieve the supplied .
-  
-  public func predicate(forToMany relationship: String, referencing object: NSManagedObject) -> NSPredicate {
-    let recordID = self.referenceObject(for: object.objectID)
-    
-    let predicateObjectRecordIDKey = "objectRecordID"
-    let predicate: NSPredicate = NSPredicate(format: "%K CONTAINS $objectRecordID", "\(relationship).sm_LocalStore_RecordID")
-    
-    return predicate.withSubstitutionVariables([predicateObjectRecordIDKey: recordID])
-  }
-  
-  /// Verify that Cloud Kit is connected and return a connection status
-  /// - SeeAlso: `verifyCloudKitConnectionAndUser(_)`
-  /// - parameter completionHandler: A closure to be invoked with the result of the Cloud Kit operations
-  /// - parameter status: The current Cloud Kit authentication status
-  /// - parameter error: Any error that resulted from the operation
-  
-  
-  @available(*,deprecated:1.0.7, message:"Use verifyCloudKitConnectionAndUser")
-  open func verifyCloudKitConnection(_ completionHandler: ((_ status: CKAccountStatus, _ error: Error?) -> Void )?) -> Void {
-    CKContainer.default().accountStatus { (status, error) in
-      
-      if status == CKAccountStatus.available {
-        self.cloudKitValid = true
-      } else {
-        self.cloudKitValid = false
-      }
-      completionHandler?(status, error)
-    }
-  }
-  
-  /// Verify that Cloud Kit is connected and return a user identifier for the current Cloud
-  /// Kit user
-  /// - parameter completionHandler: A closure to be invoked with the result of the Cloud Kit operations
-  /// - parameter status: The current Cloud Kit authentication status
-  /// - parameter userIdentifier: An identifier for the current Cloud Kit user.
-  ///   Note that this is not a userid or email address, merely a unique identifier
-  /// - parameter error: Any error that resulted from the operation
-  
-  open func verifyCloudKitConnectionAndUser(_ completionHandler: ((_ status: CKAccountStatus, _ userIdentifier: String?, _ error: Error?) -> Void )?) -> Void {
-    guard let container = self.ckContainer else {
-      completionHandler?(CKAccountStatus.couldNotDetermine ,nil,SMStoreError.invalidRequest)
-      return
-    }
-    container.accountStatus { (status, error) in
-      
-      if status == CKAccountStatus.available {
-        self.cloudKitValid = true
-      } else {
-        self.cloudKitValid = false
-      }
-      if error != nil  {
-        completionHandler?(status, nil, error)
-      } else {
-        container.fetchUserRecordID { (recordid, error) in
-          completionHandler?(status, recordid?.recordName, error)
-        }
-      }
-    }
-  }
-  
-  open func verifyCloudKitStoreExists(_ completionHandler: ((_ exists: Bool, _ error: Error?) -> Void)?) {
-    guard self.cloudKitValid else {
-      print("Access to CloudKit has not been verified by calling verifyCloudKitConnection")
-      return
-    }
-    let operation = SMServerZoneLookupOperation(cloudDatabase: database)
-    operation.lookupOperationCompletionBlock = completionHandler
-    let queue = OperationQueue()
-    queue.addOperation(operation)
-  }
-  
-  /// Trigger a sync operation.
-  /// - parameter complete: If `true` then all records are retrieved from Cloud Kit.  If `false` then only changes since the last sync are fetched
-  
-  /*open func triggerSync(complete: Bool = false, fetchCompletionHandler completion: ((Error?)->Void)? = nil) {
-   self.triggerSync(block: false, complete: complete, fetchCompletionHandler: nil)
-   }*/
-  
-  open func triggerSync(/*block: Bool, */complete: Bool = false, fetchCompletionHandler completion: ((Error?)->Void)? = nil) {
-    let c = SMStoreChangeSetHandler.defaultHandler.countOfChangeSet(backingContext: self.backingMOC)
-    VERBOSE("OK Found \(c) changes before triggerSync")
-    guard self.cloudKitValid else {
-      NSLog("Access to CloudKit has not been verified by calling verifyCloudKitConnection")
-      return
-    }
-    
-    /*if block == false {
-     guard self.operationQueue?.operationCount == 0 else {
-     print("Aborting sync; operation in progress")
-     return
-     }
+    /// Initialize this store
+    /// -SeeAlso: `NSIncrementalStore.initialize`
+    /*  override open class func initialize() {
+     NSPersistentStoreCoordinator.registerStoreClass(self, forStoreType: self.type)
      }*/
     
-    if complete {
-      SMServerTokenHandler.defaultHandler.delete()
+    /**
+     You must call this function to register the SMStore class before attempting
+     to create a store
+     */
+    
+    public class func registerStoreClass() {
+        if !storeRegistered {
+            NSPersistentStoreCoordinator.registerStoreClass(self, forStoreType: self.type)
+            storeRegistered = true
+        }
     }
     
-    let syncOperationBlock: (_ error: Error?) -> Void = { error in
-      
-      if let error = error {
-        print("Sync unsuccessful \(error)")
-        OperationQueue.main.addOperation {
-          NotificationCenter.default.post(name: Notification.Name(rawValue: SMStoreNotification.SyncDidFinish), object: self, userInfo: [SMStore.SMStoreErrorDomain:error])
-        }
-        completion?(error)
-      } else {
+    /// Returns a store initialized with the given arguments
+    /// - parameter persistentStoreCoordinator: A persistent store coordinator
+    /// - parameter configurationName: The name of the managed object model configuration to use. Pass nil if you do not want to specify a configuration.
+    /// - parameter url: The URL of the store to load.
+    /// - parameter options: A dictionary containing configuration options. See `NSPersistentStoreCoordinator` for a list of key names for options in this dictionary. `SMStoreSyncConflictResolutionPolicyOption` can also be specified in this dictionary.  `SMStoreContainerOption` can be used to specify a specific cloudkit container
+    /// - returns: A new store object, associated with coordinator, that represents a persistent store at url using the options in options and—if it is not nil—the managed object model configuration configurationName.
+    
+    override init(persistentStoreCoordinator root: NSPersistentStoreCoordinator?, configurationName name: String?, at url: URL, options: [AnyHashable: Any]?) {
         
-        self.syncOperation = SMStoreSyncOperation(persistentStoreCoordinator: self.backingPersistentStoreCoordinator, entitiesToSync: self.entitiesToParticipateInSync()!, conflictPolicy: self.cksStoresSyncConflictPolicy, database: self.database, backingMOC: self.backingMOC)
-        
-        self.syncOperation!.syncConflictResolutionBlock = self.recordConflictResolutionBlock
-        
-        self.syncOperation!.syncCompletionBlock =  { error in
-          if let error = error {
-            print("Sync unsuccessful \(error)")
-            OperationQueue.main.addOperation {
-              NotificationCenter.default.post(name: Notification.Name(rawValue: SMStoreNotification.SyncDidFinish), object: self, userInfo: [SMStore.SMStoreErrorDomain:error])
-            }
-          } else {
-            print("Sync performed successfully")
-            OperationQueue.main.addOperation {
-              NotificationCenter.default.post(name: Notification.Name(rawValue: SMStoreNotification.SyncDidFinish), object: self)
-            }
-          }
-          completion?(error)
-        }
-        self.operationQueue?.addOperation(self.syncOperation!)
-      }
-    }
-    
-    let defaults = UserDefaults.standard
-    
-    if defaults.bool(forKey: SMStore.SMStoreCloudStoreCustomZoneName) == false || defaults.bool(forKey: SMStore.SMStoreCloudStoreSubscriptionName) == false {
-      
-      self.cloudStoreSetupOperation = SMServerStoreSetupOperation(cloudDatabase: self.database)
-      self.cloudStoreSetupOperation!.setupOperationCompletionBlock = { customZoneWasCreated, customZoneSubscriptionWasCreated, error in
-        if let error = error {
-          print("Error setting up cloudkit: \(error)")
-          syncOperationBlock(error)
-        } else {
-          syncOperationBlock(nil)
-        }
-      }
-      self.operationQueue?.addOperation(self.cloudStoreSetupOperation!)
-    } else {
-      syncOperationBlock(nil)
-    }
-    NotificationCenter.default.post(name: Notification.Name(rawValue: SMStoreNotification.SyncDidStart), object: self)
-  }
-  
-  /// Handle a push notification that indicates records have been updated in Cloud Kit
-  /// - parameter userInfo: The userInfo dictionary from the push notification
-  
-  open func handlePush(userInfo:[AnyHashable: Any], fetchCompletionHandler completion: ((_ error: Error?)->Void)? = nil) {
-    let u = userInfo as! [String : NSObject]
-    let ckNotification = CKNotification(fromRemoteNotificationDictionary: u)
-    if ckNotification.notificationType == CKNotificationType.recordZone {
-      let recordZoneNotification = CKRecordZoneNotification(fromRemoteNotificationDictionary: u)
-      if let zoneID = recordZoneNotification.recordZoneID {
-        if zoneID.zoneName == SMStore.SMStoreCloudStoreCustomZoneName {
-          //self.triggerSync(block: true)
-          self.triggerSync(complete: false, fetchCompletionHandler: completion)
-        }
-      }
-    }
-  }
-  
-  func createBackingStore() throws {
-    let storeURL=self.url
-    guard let backingMOM = self.backingModel() else {
-      throw SMStoreError.backingStoreCreationFailed
-    }
-    self.backingPersistentStoreCoordinator = NSPersistentStoreCoordinator(managedObjectModel: backingMOM)
-    do {
-      
-      let options = [NSMigratePersistentStoresAutomaticallyOption: self.automaticStoreMigration, NSInferMappingModelAutomaticallyOption: self.inferMappingModel]
-      
-      self.backingPersistentStore = try self.backingPersistentStoreCoordinator?.addPersistentStore(ofType: NSSQLiteStoreType, configurationName: nil, at: storeURL, options: options)
-      self.operationQueue = OperationQueue()
-      self.operationQueue!.maxConcurrentOperationCount = 1
-    } catch {
-      throw SMStoreError.backingStoreCreationFailed
-    }
-    return
-  }
-  
-  func backingModel() -> NSManagedObjectModel? {
-    if let persistentStoreModel = self.persistentStoreCoordinator?.managedObjectModel {
-      let backingModel: NSManagedObjectModel = SMStoreChangeSetHandler.defaultHandler.modelForLocalStore(usingModel: persistentStoreModel)
-      return backingModel
-    }
-    return nil
-  }
-  
-  func entitiesToParticipateInSync() -> [NSEntityDescription]? {
-    let syncEntities =  self.backingMOC.persistentStoreCoordinator?.managedObjectModel.entities.filter { object in
-      let entity: NSEntityDescription = object
-      return (entity.name)! != SMStore.SMLocalStoreChangeSetEntityName
-    }
-    
-    return syncEntities
-  }
-  
-  
-  override open func execute(_ request: NSPersistentStoreRequest, with context: NSManagedObjectContext?) throws -> Any {
-    //do {
-    if request.requestType == NSPersistentStoreRequestType.fetchRequestType {
-      let fetchRequest = request as! NSFetchRequest<NSFetchRequestResult>
-      if fetchRequest.resultType == .countResultType {
-        return try self.executeInResponseToCountFetchRequest(fetchRequest, context: context!)
-      } else {
-        return try self.executeInResponseToFetchRequest(fetchRequest, context: context!)
-      }
-    } else if request.requestType == NSPersistentStoreRequestType.saveRequestType {
-      let saveChangesRequest: NSSaveChangesRequest = request as! NSSaveChangesRequest
-      return try self.executeInResponseToSaveChangesRequest(saveChangesRequest, context: context!)
-    } else {
-      throw NSError(domain: SMStore.SMStoreErrorDomain, code: SMStoreError.invalidRequest._code, userInfo: nil)
-    }
-    /*} catch {
-    print("OKERROR \(error)")
-    throw error
-    }*/
-  }
-  
-  override open func newValuesForObject(with objectID: NSManagedObjectID, with context: NSManagedObjectContext) throws -> NSIncrementalStoreNode {
-    
-    let targetEntities = context.persistentStoreCoordinator!.managedObjectModel.entitiesByName
-    
-    let recordID:String = self.referenceObject(for: objectID) as! String
-    let propertiesToFetch = Array(objectID.entity.propertiesByName.values).filter { object  in
-      if let relationshipDescription = object as? NSRelationshipDescription {
-        return relationshipDescription.isToMany == false
-      }
-      return true
-      }.map {
-        return $0.name
-    }
-    let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: objectID.entity.name!)
-    let predicate = NSPredicate(format: "%K == %@", SMStore.SMLocalStoreRecordIDAttributeName,recordID)
-    fetchRequest.fetchLimit = 1
-    fetchRequest.predicate = predicate
-    fetchRequest.resultType = NSFetchRequestResultType.dictionaryResultType
-    fetchRequest.propertiesToFetch = propertiesToFetch
-    let results = try self.backingMOC.fetch(fetchRequest)
-    var incrementalStoreNode = NSIncrementalStoreNode(objectID: objectID, withValues: [:], version: 1)
-    if var backingObjectValues = results.last as? Dictionary<String,NSObject> {
-      for (key,value) in backingObjectValues {
-        if let managedObjectID = value as? NSManagedObjectID {
-          let managedObject = try self.backingMOC.existingObject(with: managedObjectID)
-          if let identifier = managedObject.value(forKey: SMStore.SMLocalStoreRecordIDAttributeName) as? String {
-            if let targetEntity = targetEntities[managedObject.entity.name!] {
-              let objID = self.newObjectID(for: targetEntity, referenceObject:identifier)
-              
-              backingObjectValues[key] = objID
-            }
-          }
-        }
-      }
-      
-      incrementalStoreNode = NSIncrementalStoreNode(objectID: objectID, withValues: backingObjectValues, version: 1)
-    }
-    return incrementalStoreNode
-    
-  }
-  
-  override open func newValue(forRelationship relationship: NSRelationshipDescription, forObjectWith objectID: NSManagedObjectID, with context: NSManagedObjectContext?) throws -> Any {
-    
-    if relationship.isToMany {
-      guard let targetRelationship = relationship.inverseRelationship else {
-        throw SMStoreError.missingInverseRelationship
-      }
-      guard targetRelationship.isToMany == false else {
-        throw SMStoreError.manyToManyUnsupported
-      }
-      
-      return try self.toManyValues(forRelationship: targetRelationship, forObjectWith: objectID, with: context)
-    } else {
-      return try self.toOneValue(forRelationship: relationship, forObjectWith: objectID, with: context)
-    }
-  }
-  
-  fileprivate func toOneValue(forRelationship relationship: NSRelationshipDescription, forObjectWith objectID: NSManagedObjectID, with context: NSManagedObjectContext?) throws -> Any {
-    
-    let recordID:String = self.referenceObject(for: objectID) as! String
-    
-    let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: objectID.entity.name!)
-    let predicate = NSPredicate(format: "%K == %@", SMStore.SMLocalStoreRecordIDAttributeName,recordID)
-    fetchRequest.fetchLimit = 1
-    fetchRequest.predicate = predicate
-    fetchRequest.resultType = NSFetchRequestResultType.dictionaryResultType
-    let results = try self.backingMOC.fetch(fetchRequest)
-    
-    if let result = results.last as? [String:NSObject] {
-      if let referencedObject = result[relationship.name] {
-        return self.newObjectID(for: relationship.destinationEntity!, referenceObject: referencedObject)
-      }
-    }
-    
-    if relationship.isOptional {
-      return NSNull()
-    } else {
-      throw SMStoreError.missingRelatedObject
-    }
-  }
-  
-  
-  fileprivate func toManyValues(forRelationship relationship: NSRelationshipDescription, forObjectWith objectID: NSManagedObjectID, with context: NSManagedObjectContext?) throws -> [NSManagedObjectID] {
-    
-    let recordID:String = self.referenceObject(for: objectID) as! String
-    
-    if let targetObjectID = try self.objectIDForBackingObjectForEntity(objectID.entity.name!, withReferenceObject: recordID) {
-      
-      let targetsFetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: relationship.entity.name!)
-      let targetsPredicate = NSPredicate(format: "%K == %@", relationship.name,targetObjectID)
-      targetsFetchRequest.predicate = targetsPredicate
-      targetsFetchRequest.resultType = .managedObjectResultType
-      targetsFetchRequest.propertiesToFetch = [SMStore.SMLocalStoreRecordIDAttributeName]
-      if let targetResults = try self.backingMOC.fetch(targetsFetchRequest) as? [NSManagedObject] {
-        if !targetResults.isEmpty {
-          let retValues = targetResults.map {
-            let reference = $0.value(forKey: SMStore.SMLocalStoreRecordIDAttributeName)
-            return self.newObjectID(for: relationship.entity, referenceObject: reference as Any)
+        if let opts = options {
             
-            } as [NSManagedObjectID]
-          return retValues
-        }
-      }
-    }
-    return [NSManagedObjectID]()
-  }
-  
-  
-  override open func obtainPermanentIDs(for array: [NSManagedObject]) throws -> [NSManagedObjectID] {
-    return array.map { object in
-      let insertedObject:NSManagedObject = object as NSManagedObject
-      let newRecordID: String = UUID().uuidString
-      return self.newObjectID(for: insertedObject.entity, referenceObject: newRecordID)
-    }
-  }
-  
-  // MARK : Fetch Request
-  func executeInResponseToFetchRequest(_ fetchRequest:NSFetchRequest<NSFetchRequestResult>,context:NSManagedObjectContext) throws ->[Any] {
-    let resultsFromLocalStore = try self.backingMOC.fetch(fetchRequest)
-    if !resultsFromLocalStore.isEmpty {
-      switch fetchRequest.resultType {
-      case .managedObjectResultType:
-        return resultsFromLocalStore.map({(result)->NSManagedObject in
-          let result = result as! NSManagedObject
-          let recordID: String = result.value(forKey: SMStore.SMLocalStoreRecordIDAttributeName) as! String
-          let entity = self.persistentStoreCoordinator?.managedObjectModel.entitiesByName[fetchRequest.entityName!]
-          let objectID = self.newObjectID(for: entity!, referenceObject: recordID)
-          let object = context.object(with: objectID)
-          return object
-        })
-        
-      case .dictionaryResultType:
-        return resultsFromLocalStore.map({(result)->[String:Any] in
-          var result = result as! [String:Any]
-          result[SMStore.SMLocalStoreRecordIDAttributeName] = nil
-          return result
-        })
-      case .managedObjectIDResultType:
-        return resultsFromLocalStore.map({(result)->NSManagedObjectID in
-          let result = result as! NSManagedObjectID
-          let object = self.backingMOC.registeredObject(for: result)!
-          let recordID: String = object.value(forKey: SMStore.SMLocalStoreRecordIDAttributeName) as! String
-          let entity = self.persistentStoreCoordinator?.managedObjectModel.entitiesByName[fetchRequest.entityName!]
-          let objectID = self.newObjectID(for: entity!, referenceObject: recordID)
-          return objectID
-        })
-      case .countResultType:
-        return [resultsFromLocalStore.count]
-      default:
-        break
-      }
-    }
-    return []
-  }
-  
-  func executeInResponseToCountFetchRequest(_ fetchRequest:NSFetchRequest<NSFetchRequestResult>,context:NSManagedObjectContext) throws ->[Int] {
-    let resultsFromLocalStore = try self.backingMOC.count(for:fetchRequest)
-    return [resultsFromLocalStore]
-  }
-  
-  // MARK : SaveChanges Request
-  fileprivate func executeInResponseToSaveChangesRequest(_ saveRequest:NSSaveChangesRequest,context:NSManagedObjectContext) throws -> Array<AnyObject> {
-    try self.deleteObjectsFromBackingStore(objectsToDelete: context.deletedObjects, mainContext: context)
-    try self.insertObjectsInBackingStore(objectsToInsert: context.insertedObjects, mainContext: context)
-    try self.updateObjectsInBackingStore(objectsToUpdate: context.updatedObjects)
-
-    
-    try self.backingMOC.saveIfHasChanges()
-    if self.syncAutomatically {
-      self.triggerSync()
-    }
-    return []
-  }
-  
-  func objectIDForBackingObjectForEntity(_ entityName: String, withReferenceObject referenceObject: String?) throws -> NSManagedObjectID? {
-    if referenceObject == nil {
-      return nil
-    }
-    let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: entityName)
-    fetchRequest.resultType = NSFetchRequestResultType.managedObjectIDResultType
-    fetchRequest.fetchLimit = 1
-    fetchRequest.predicate = NSPredicate(format: "%K == %@", SMStore.SMLocalStoreRecordIDAttributeName,referenceObject!)
-    let results = try self.backingMOC.fetch(fetchRequest)
-    if !results.isEmpty {
-      return results.last as? NSManagedObjectID
-    }
-    return nil
-  }
-  
-  fileprivate func setRelationshipValuesForBackingObject(_ backingObject:NSManagedObject,sourceObject:NSManagedObject) throws -> Void {
-    for relationship in Array(sourceObject.entity.relationshipsByName.values) as [NSRelationshipDescription] {
-      if sourceObject.hasFault(forRelationshipNamed: relationship.name) || sourceObject.value(forKey: relationship.name) == nil {
-        continue
-      }
-      if relationship.isToMany  {
-        let relationshipValue: Set<NSObject> = sourceObject.value(forKey: relationship.name) as! Set<NSObject>
-        var backingRelationshipValue: Set<NSObject> = Set<NSObject>()
-        for relationshipObject in relationshipValue {
-          let relationshipManagedObject: NSManagedObject = relationshipObject as! NSManagedObject
-          if relationshipManagedObject.objectID.isTemporaryID == false {
-            let referenceObject: String = self.referenceObject(for: relationshipManagedObject.objectID) as! String
-            let backingRelationshipObjectID = try self.objectIDForBackingObjectForEntity(relationship.destinationEntity!.name!, withReferenceObject: referenceObject)
-            if backingRelationshipObjectID != nil {
-              let backingRelationshipObject = try backingObject.managedObjectContext?.existingObject(with: backingRelationshipObjectID!)
-              backingRelationshipValue.insert(backingRelationshipObject!)
+            if let containerIdentifier = opts[SMStore.SMStoreContainerOption] as? String {
+                self.ckContainer = CKContainer(identifier: containerIdentifier)
             }
-          }
+            
+            if let syncConflictPolicyRawValue = opts[SMStore.SMStoreSyncConflictResolutionPolicyOption] as? NSNumber {
+                if let syncConflictPolicy = SMSyncConflictResolutionPolicy(rawValue: syncConflictPolicyRawValue.int16Value) {
+                    self.cksStoresSyncConflictPolicy = syncConflictPolicy
+                }
+            }
+            
+            if let migrationPolicy = opts[NSMigratePersistentStoresAutomaticallyOption] as? Bool {
+                self.automaticStoreMigration = migrationPolicy
+            }
+            
+            if let inferMapping = opts[NSInferMappingModelAutomaticallyOption] as? Bool {
+                self.inferMappingModel = inferMapping
+            }
+            
         }
-        backingObject.setValue(backingRelationshipValue, forKey: relationship.name)
-      } else {
-        let relationshipValue: NSManagedObject = sourceObject.value(forKey: relationship.name) as! NSManagedObject
-        if relationshipValue.objectID.isTemporaryID == false {
-          let referenceObject: String = self.referenceObject(for: relationshipValue.objectID) as! String
-          let backingRelationshipObjectID = try self.objectIDForBackingObjectForEntity(relationship.destinationEntity!.name!, withReferenceObject: referenceObject)
-          if backingRelationshipObjectID != nil {
-            let backingRelationshipObject = try self.backingMOC.existingObject(with: backingRelationshipObjectID!)
-            backingObject.setValue(backingRelationshipObject, forKey: relationship.name)
-          }
+        
+        if self.ckContainer == nil {
+            self.ckContainer = CKContainer.default()
         }
-      }
+        
+        self.database = self.ckContainer!.privateCloudDatabase
+        
+        super.init(persistentStoreCoordinator: root, configurationName: name, at: url, options: options)
     }
-  }
-  
-  func insertObjectsInBackingStore(objectsToInsert objects:Set<NSObject>, mainContext: NSManagedObjectContext) throws -> Void {
-    let mobs = Array(objects) as! [NSManagedObject]
-    let sorted = SMObjectDependencyGraph(objects: mobs).sorted as! [NSManagedObject]
-    for object in sorted {
-      
-      let sourceObject: NSManagedObject = object
-      let managedObject:NSManagedObject = NSEntityDescription.insertNewObject(forEntityName: (sourceObject.entity.name)!, into: self.backingMOC) as NSManagedObject
-      let keys = Array(sourceObject.entity.attributesByName.keys)
-      let dictionary = sourceObject.dictionaryWithValues(forKeys: keys)
-      managedObject.setValuesForKeys(dictionary)
-      let referenceObject: String = self.referenceObject(for: sourceObject.objectID) as! String
-      managedObject.setValue(referenceObject, forKey: SMStore.SMLocalStoreRecordIDAttributeName)
-      mainContext.willChangeValue(forKey: "objectID")
-      try mainContext.obtainPermanentIDs(for: [sourceObject])
-      mainContext.didChangeValue(forKey: "objectID")
-      SMStoreChangeSetHandler.defaultHandler.createChangeSet(ForInsertedObjectRecordID: referenceObject, entityName: sourceObject.entity.name!, backingContext: self.backingMOC)
-      try self.setRelationshipValuesForBackingObject(managedObject, sourceObject: sourceObject)
-      // Don't save the MOC here: rolling up all the saves into a single one will prevent saving data in an inconsistent save
-      // All saves are now performed in 'executeInResponseToSaveChangesRequest()'
+    
+    /// The type string of the receiver. (`SMStore`)
+    
+    class open var type:String {
+        return NSStringFromClass(self)
     }
-  }
-  
-  fileprivate func deleteObjectsFromBackingStore(objectsToDelete objects: Set<NSObject>, mainContext: NSManagedObjectContext) throws -> Void {
-    let predicateObjectRecordIDKey = "objectRecordID"
-    let predicate: NSPredicate = NSPredicate(format: "%K == $objectRecordID", SMStore.SMLocalStoreRecordIDAttributeName)
-    for object in objects {
-      let sourceObject: NSManagedObject = object as! NSManagedObject
-      let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: sourceObject.entity.name!)
-      let recordID: String = self.referenceObject(for: sourceObject.objectID) as! String
-      fetchRequest.predicate = predicate.withSubstitutionVariables([predicateObjectRecordIDKey: recordID])
-      fetchRequest.fetchLimit = 1
-      let results = try self.backingMOC.fetch(fetchRequest)
-      if !results.isEmpty {
-        if let backingObject: NSManagedObject = results.last as? NSManagedObject {
-          SMStoreChangeSetHandler.defaultHandler.createChangeSet(ForDeletedObjectRecordID: recordID, backingContext: self.backingMOC)
-          self.backingMOC.delete(backingObject)
-          // Don't save the MOC here: rolling up all the saves into a single one will prevent saving data in an inconsistent save
-          // All saves are now performed in 'executeInResponseToSaveChangesRequest()'
+    
+    
+    /// Instructs the receiver to load its metadata.
+    /// - returns: `true` if the metadata was loaded correctly, otherwise `false`.
+    /// - throws: An `SMStoreError` if the backing store could not be created
+    
+    override open func loadMetadata() throws {
+        self.metadata=[
+            NSStoreUUIDKey: "A9909604-1EF0-4049-BD7F-2CF6AE3D3A6D",
+            NSStoreTypeKey: Swift.type(of: self).type
+        ]
+        
+        try self.createBackingStore()
+    }
+    
+    /// Reset the backing store.  This function should be called where the local store should be cleared prior to a re-sync from the cloud.  E.g. Where a change in CloudKit user has been identified.
+    /// - throws: An `SMStoreError` if the backing store could not be reset
+    public func resetBackingStore() throws {
+        
+        guard let backingMOM = self.backingModel() else {
+            throw SMStoreError.backingStoreResetFailed
         }
-      }
-    }
-  }
-  
-  fileprivate func updateObjectsInBackingStore(objectsToUpdate objects: Set<NSObject>) throws -> Void {
-    let predicateObjectRecordIDKey = "objectRecordID"
-    let predicate: NSPredicate = NSPredicate(format: "%K == $objectRecordID", SMStore.SMLocalStoreRecordIDAttributeName)
-    for object in objects {
-      let sourceObject: NSManagedObject = object as! NSManagedObject
-      let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: sourceObject.entity.name!)
-      let recordID: String = self.referenceObject(for: sourceObject.objectID) as! String
-      fetchRequest.predicate = predicate.withSubstitutionVariables([predicateObjectRecordIDKey:recordID])
-      fetchRequest.fetchLimit = 1
-      let results = try self.backingMOC.fetch(fetchRequest)
-      if !results.isEmpty {
-        if let backingObject: NSManagedObject = results.last as? NSManagedObject {
-          let keys = Array(self.persistentStoreCoordinator!.managedObjectModel.entitiesByName[sourceObject.entity.name!]!.attributesByName.keys)
-          let sourceObjectValues = sourceObject.dictionaryWithValues(forKeys: keys)
-          backingObject.setValuesForKeys(sourceObjectValues)
-          SMStoreChangeSetHandler.defaultHandler.createChangeSet(ForUpdatedObject: backingObject, usingContext: self.backingMOC)
-          try self.setRelationshipValuesForBackingObject(backingObject, sourceObject: sourceObject)
-          // Don't save the MOC here: rolling up all the saves into a single one will prevent saving data in an inconsistent save
-          // All saves are now performed in 'executeInResponseToSaveChangesRequest()'
+        
+        for entity in backingMOM.entities {
+            let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: entity.name!)
+            let deleteRequest = NSBatchDeleteRequest(fetchRequest: fetchRequest)
+            
+            try self.backingMOC.execute(deleteRequest)
+            
         }
-      }
+        
+        
+        let defaults = UserDefaults.standard
+        
+        defaults.set(false, forKey:SMStore.SMStoreCloudStoreCustomZoneName)
+        
+        defaults.set(false, forKey:SMStore.SMStoreCloudStoreSubscriptionName)
     }
-  }
+    
+    /// Retrieve an `NSPredicate` that will match the supplied `NSManagedObject`.
+    /// - parameter for: The name of the relationship that holds the reference to the target object
+    /// - parameter object: The related `NSManagedObject` to search for
+    /// - returns: An `NSPredicate` that will retrieve the supplied object.
+    
+    public func predicate(for relationship: String, referencing object: NSManagedObject) -> NSPredicate {
+        let recordID = self.referenceObject(for: object.objectID)
+        
+        let predicateObjectRecordIDKey = "objectRecordID"
+        let predicate: NSPredicate = NSPredicate(format: "%K == $objectRecordID", "\(relationship).sm_LocalStore_RecordID")
+        
+        return predicate.withSubstitutionVariables([predicateObjectRecordIDKey: recordID])
+    }
+    
+    /// Retrieve an `NSPredicate` that will match the supplied `NSManagedObject` in a to-many.
+    /// - parameter forToMany: The name of the to-many relationship that holds the reference to the target object
+    /// - parameter object: The related `NSManagedObject` to search for
+    /// - returns: An `NSPredicate` that will retrieve the supplied .
+    
+    public func predicate(forToMany relationship: String, referencing object: NSManagedObject) -> NSPredicate {
+        let recordID = self.referenceObject(for: object.objectID)
+        
+        let predicateObjectRecordIDKey = "objectRecordID"
+        let predicate: NSPredicate = NSPredicate(format: "%K CONTAINS $objectRecordID", "\(relationship).sm_LocalStore_RecordID")
+        
+        return predicate.withSubstitutionVariables([predicateObjectRecordIDKey: recordID])
+    }
+    
+    /// Verify that Cloud Kit is connected and return a connection status
+    /// - SeeAlso: `verifyCloudKitConnectionAndUser(_)`
+    /// - parameter completionHandler: A closure to be invoked with the result of the Cloud Kit operations
+    /// - parameter status: The current Cloud Kit authentication status
+    /// - parameter error: Any error that resulted from the operation
+    
+    
+    @available(*,deprecated:1.0.7, message:"Use verifyCloudKitConnectionAndUser")
+    open func verifyCloudKitConnection(_ completionHandler: ((_ status: CKAccountStatus, _ error: Error?) -> Void )?) -> Void {
+        CKContainer.default().accountStatus { (status, error) in
+            
+            if status == CKAccountStatus.available {
+                self.cloudKitValid = true
+            } else {
+                self.cloudKitValid = false
+            }
+            completionHandler?(status, error)
+        }
+    }
+    
+    /// Verify that Cloud Kit is connected and return a user identifier for the current Cloud
+    /// Kit user
+    /// - parameter completionHandler: A closure to be invoked with the result of the Cloud Kit operations
+    /// - parameter status: The current Cloud Kit authentication status
+    /// - parameter userIdentifier: An identifier for the current Cloud Kit user.
+    ///   Note that this is not a userid or email address, merely a unique identifier
+    /// - parameter error: Any error that resulted from the operation
+    
+    open func verifyCloudKitConnectionAndUser(_ completionHandler: ((_ status: CKAccountStatus, _ userIdentifier: String?, _ error: Error?) -> Void )?) -> Void {
+        guard let container = self.ckContainer else {
+            completionHandler?(CKAccountStatus.couldNotDetermine ,nil,SMStoreError.invalidRequest)
+            return
+        }
+        container.accountStatus { (status, error) in
+            
+            if status == CKAccountStatus.available {
+                self.cloudKitValid = true
+            } else {
+                self.cloudKitValid = false
+            }
+            if error != nil  {
+                completionHandler?(status, nil, error)
+            } else {
+                container.fetchUserRecordID { (recordid, error) in
+                    completionHandler?(status, recordid?.recordName, error)
+                }
+            }
+        }
+    }
+    
+    open func verifyCloudKitStoreExists(_ completionHandler: ((_ exists: Bool, _ error: Error?) -> Void)?) {
+        guard self.cloudKitValid else {
+            print("Access to CloudKit has not been verified by calling verifyCloudKitConnection")
+            return
+        }
+        let operation = SMServerZoneLookupOperation(cloudDatabase: database)
+        operation.lookupOperationCompletionBlock = completionHandler
+        let queue = OperationQueue()
+        queue.addOperation(operation)
+    }
+    
+    /// Trigger a sync operation.
+    /// - parameter complete: If `true` then all records are retrieved from Cloud Kit.  If `false` then only changes since the last sync are fetched
+    
+    /*open func triggerSync(complete: Bool = false, fetchCompletionHandler completion: ((Error?)->Void)? = nil) {
+     self.triggerSync(block: false, complete: complete, fetchCompletionHandler: nil)
+     }*/
+    
+    open func triggerSync(complete: Bool = false, fetchCompletionHandler completion: ((Error?)->Void)? = nil) {
+        guard self.cloudKitValid else {
+            print("Access to CloudKit has not been verified by calling verifyCloudKitConnection")
+            return
+        }
+        
+        if complete {
+            SMServerTokenHandler.defaultHandler.delete()
+        }
+        
+        let syncOperationBlock: (_ error: Error?) -> Void = { error in
+            
+            if let error = error {
+                print("Sync unsuccessful \(error)")
+                OperationQueue.main.addOperation {
+                    NotificationCenter.default.post(name: Notification.Name(rawValue: SMStoreNotification.SyncDidFinish), object: self, userInfo: [SMStore.SMStoreErrorDomain:error])
+                }
+                completion?(error)
+            } else {
+                
+                self.syncOperation = SMStoreSyncOperation(persistentStoreCoordinator: self.backingPersistentStoreCoordinator, entitiesToSync: self.entitiesToParticipateInSync()!, conflictPolicy: self.cksStoresSyncConflictPolicy, database: self.database, backingMOC: self.backingMOC)
+                
+                self.syncOperation!.syncConflictResolutionBlock = self.recordConflictResolutionBlock
+                
+                self.syncOperation!.syncCompletionBlock =  { error in
+                    if let error = error {
+                        print("Sync unsuccessful \(error)")
+                        OperationQueue.main.addOperation {
+                            NotificationCenter.default.post(name: Notification.Name(rawValue: SMStoreNotification.SyncDidFinish), object: self, userInfo: [SMStore.SMStoreErrorDomain:error])
+                        }
+                    } else {
+                        print("Sync performed successfully")
+                        OperationQueue.main.addOperation {
+                            NotificationCenter.default.post(name: Notification.Name(rawValue: SMStoreNotification.SyncDidFinish), object: self)
+                        }
+                    }
+                    completion?(error)
+                }
+                self.operationQueue?.addOperation(self.syncOperation!)
+            }
+        }
+        
+        let defaults = UserDefaults.standard
+        
+        if defaults.bool(forKey: SMStore.SMStoreCloudStoreCustomZoneName) == false || defaults.bool(forKey: SMStore.SMStoreCloudStoreSubscriptionName) == false {
+            
+            self.cloudStoreSetupOperation = SMServerStoreSetupOperation(cloudDatabase: self.database)
+            self.cloudStoreSetupOperation!.setupOperationCompletionBlock = { customZoneWasCreated, customZoneSubscriptionWasCreated, error in
+                if let error = error {
+                    print("Error setting up cloudkit: \(error)")
+                    syncOperationBlock(error)
+                } else {
+                    syncOperationBlock(nil)
+                }
+            }
+            self.operationQueue?.addOperation(self.cloudStoreSetupOperation!)
+        } else {
+            syncOperationBlock(nil)
+        }
+        NotificationCenter.default.post(name: Notification.Name(rawValue: SMStoreNotification.SyncDidStart), object: self)
+    }
+    
+    /// Handle a push notification that indicates records have been updated in Cloud Kit
+    /// - parameter userInfo: The userInfo dictionary from the push notification
+    
+    open func handlePush(userInfo:[AnyHashable: Any], fetchCompletionHandler completion: ((_ error: Error?)->Void)? = nil) {
+        let u = userInfo as! [String : NSObject]
+        let ckNotification = CKNotification(fromRemoteNotificationDictionary: u)
+        if ckNotification.notificationType == CKNotificationType.recordZone {
+            let recordZoneNotification = CKRecordZoneNotification(fromRemoteNotificationDictionary: u)
+            if let zoneID = recordZoneNotification.recordZoneID {
+                if zoneID.zoneName == SMStore.SMStoreCloudStoreCustomZoneName {
+                    //self.triggerSync(block: true)
+                    self.triggerSync(complete: false, fetchCompletionHandler: completion)
+                }
+            }
+        }
+    }
+    
+    func createBackingStore() throws {
+        let storeURL=self.url
+        guard let backingMOM = self.backingModel() else {
+            throw SMStoreError.backingStoreCreationFailed
+        }
+        self.backingPersistentStoreCoordinator = NSPersistentStoreCoordinator(managedObjectModel: backingMOM)
+        do {
+            
+            let options = [NSMigratePersistentStoresAutomaticallyOption: self.automaticStoreMigration, NSInferMappingModelAutomaticallyOption: self.inferMappingModel]
+            
+            self.backingPersistentStore = try self.backingPersistentStoreCoordinator?.addPersistentStore(ofType: NSSQLiteStoreType, configurationName: nil, at: storeURL, options: options)
+            self.operationQueue = OperationQueue()
+            self.operationQueue!.maxConcurrentOperationCount = 1
+        } catch {
+            throw SMStoreError.backingStoreCreationFailed
+        }
+        return
+    }
+    
+    func backingModel() -> NSManagedObjectModel? {
+        if let persistentStoreModel = self.persistentStoreCoordinator?.managedObjectModel {
+            let backingModel: NSManagedObjectModel = SMStoreChangeSetHandler.defaultHandler.modelForLocalStore(usingModel: persistentStoreModel)
+            return backingModel
+        }
+        return nil
+    }
+    
+    func entitiesToParticipateInSync() -> [NSEntityDescription]? {
+        let syncEntities =  self.backingMOC.persistentStoreCoordinator?.managedObjectModel.entities.filter { object in
+            let entity: NSEntityDescription = object
+            return (entity.name)! != SMStore.SMLocalStoreChangeSetEntityName
+        }
+        
+        return syncEntities
+    }
+    
+    
+    override open func execute(_ request: NSPersistentStoreRequest, with context: NSManagedObjectContext?) throws -> Any {
+        //do {
+        if request.requestType == NSPersistentStoreRequestType.fetchRequestType {
+            let fetchRequest = request as! NSFetchRequest<NSFetchRequestResult>
+            if fetchRequest.resultType == .countResultType {
+                return try self.executeInResponseToCountFetchRequest(fetchRequest, context: context!)
+            } else {
+                return try self.executeInResponseToFetchRequest(fetchRequest, context: context!)
+            }
+        } else if request.requestType == NSPersistentStoreRequestType.saveRequestType {
+            let saveChangesRequest: NSSaveChangesRequest = request as! NSSaveChangesRequest
+            return try self.executeInResponseToSaveChangesRequest(saveChangesRequest, context: context!)
+        } else {
+            throw NSError(domain: SMStore.SMStoreErrorDomain, code: SMStoreError.invalidRequest._code, userInfo: nil)
+        }
+        /*} catch {
+         print("OKERROR \(error)")
+         throw error
+         }*/
+    }
+    
+    override open func newValuesForObject(with objectID: NSManagedObjectID, with context: NSManagedObjectContext) throws -> NSIncrementalStoreNode {
+        
+        let targetEntities = context.persistentStoreCoordinator!.managedObjectModel.entitiesByName
+        
+        let recordID:String = self.referenceObject(for: objectID) as! String
+        let propertiesToFetch = Array(objectID.entity.propertiesByName.values).filter { object  in
+            if let relationshipDescription = object as? NSRelationshipDescription {
+                return relationshipDescription.isToMany == false
+            }
+            return true
+            }.map {
+                return $0.name
+        }
+        let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: objectID.entity.name!)
+        let predicate = NSPredicate(format: "%K == %@", SMStore.SMLocalStoreRecordIDAttributeName,recordID)
+        fetchRequest.fetchLimit = 1
+        fetchRequest.predicate = predicate
+        fetchRequest.resultType = NSFetchRequestResultType.dictionaryResultType
+        fetchRequest.propertiesToFetch = propertiesToFetch
+        let results = try self.backingMOC.fetch(fetchRequest)
+        var incrementalStoreNode = NSIncrementalStoreNode(objectID: objectID, withValues: [:], version: 1)
+        if var backingObjectValues = results.last as? Dictionary<String,NSObject> {
+            for (key,value) in backingObjectValues {
+                if let managedObjectID = value as? NSManagedObjectID {
+                    let managedObject = try self.backingMOC.existingObject(with: managedObjectID)
+                    if let identifier = managedObject.value(forKey: SMStore.SMLocalStoreRecordIDAttributeName) as? String {
+                        if let targetEntity = targetEntities[managedObject.entity.name!] {
+                            let objID = self.newObjectID(for: targetEntity, referenceObject:identifier)
+                            
+                            backingObjectValues[key] = objID
+                        }
+                    }
+                }
+            }
+            
+            incrementalStoreNode = NSIncrementalStoreNode(objectID: objectID, withValues: backingObjectValues, version: 1)
+        }
+        return incrementalStoreNode
+        
+    }
+    
+    override open func newValue(forRelationship relationship: NSRelationshipDescription, forObjectWith objectID: NSManagedObjectID, with context: NSManagedObjectContext?) throws -> Any {
+        
+        if relationship.isToMany {
+            guard let targetRelationship = relationship.inverseRelationship else {
+                throw SMStoreError.missingInverseRelationship
+            }
+            guard targetRelationship.isToMany == false else {
+                throw SMStoreError.manyToManyUnsupported
+            }
+            
+            return try self.toManyValues(forRelationship: targetRelationship, forObjectWith: objectID, with: context)
+        } else {
+            return try self.toOneValue(forRelationship: relationship, forObjectWith: objectID, with: context)
+        }
+    }
+    
+    fileprivate func toOneValue(forRelationship relationship: NSRelationshipDescription, forObjectWith objectID: NSManagedObjectID, with context: NSManagedObjectContext?) throws -> Any {
+        
+        let recordID:String = self.referenceObject(for: objectID) as! String
+        
+        let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: objectID.entity.name!)
+        let predicate = NSPredicate(format: "%K == %@", SMStore.SMLocalStoreRecordIDAttributeName,recordID)
+        fetchRequest.fetchLimit = 1
+        fetchRequest.predicate = predicate
+        fetchRequest.resultType = NSFetchRequestResultType.dictionaryResultType
+        let results = try self.backingMOC.fetch(fetchRequest)
+        
+        if let result = results.last as? [String:NSObject] {
+            if let referencedObject = result[relationship.name] {
+                return self.newObjectID(for: relationship.destinationEntity!, referenceObject: referencedObject)
+            }
+        }
+        
+        if relationship.isOptional {
+            return NSNull()
+        } else {
+            throw SMStoreError.missingRelatedObject
+        }
+    }
+    
+    
+    fileprivate func toManyValues(forRelationship relationship: NSRelationshipDescription, forObjectWith objectID: NSManagedObjectID, with context: NSManagedObjectContext?) throws -> [NSManagedObjectID] {
+        
+        let recordID:String = self.referenceObject(for: objectID) as! String
+        
+        if let targetObjectID = try self.objectIDForBackingObjectForEntity(objectID.entity.name!, withReferenceObject: recordID) {
+            
+            let targetsFetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: relationship.entity.name!)
+            let targetsPredicate = NSPredicate(format: "%K == %@", relationship.name,targetObjectID)
+            targetsFetchRequest.predicate = targetsPredicate
+            targetsFetchRequest.resultType = .managedObjectResultType
+            targetsFetchRequest.propertiesToFetch = [SMStore.SMLocalStoreRecordIDAttributeName]
+            if let targetResults = try self.backingMOC.fetch(targetsFetchRequest) as? [NSManagedObject] {
+                if !targetResults.isEmpty {
+                    let retValues = targetResults.map {
+                        let reference = $0.value(forKey: SMStore.SMLocalStoreRecordIDAttributeName)
+                        return self.newObjectID(for: relationship.entity, referenceObject: reference as Any)
+                        
+                        } as [NSManagedObjectID]
+                    return retValues
+                }
+            }
+        }
+        return [NSManagedObjectID]()
+    }
+    
+    
+    override open func obtainPermanentIDs(for array: [NSManagedObject]) throws -> [NSManagedObjectID] {
+        return array.map { object in
+            let insertedObject:NSManagedObject = object as NSManagedObject
+            let newRecordID: String = UUID().uuidString
+            return self.newObjectID(for: insertedObject.entity, referenceObject: newRecordID)
+        }
+    }
+    
+    // MARK : Fetch Request
+    func executeInResponseToFetchRequest(_ fetchRequest:NSFetchRequest<NSFetchRequestResult>,context:NSManagedObjectContext) throws ->[Any] {
+        let resultsFromLocalStore = try self.backingMOC.fetch(fetchRequest)
+        if !resultsFromLocalStore.isEmpty {
+            switch fetchRequest.resultType {
+            case .managedObjectResultType:
+                return resultsFromLocalStore.map({(result)->NSManagedObject in
+                    let result = result as! NSManagedObject
+                    let recordID: String = result.value(forKey: SMStore.SMLocalStoreRecordIDAttributeName) as! String
+                    let entity = self.persistentStoreCoordinator?.managedObjectModel.entitiesByName[fetchRequest.entityName!]
+                    let objectID = self.newObjectID(for: entity!, referenceObject: recordID)
+                    let object = context.object(with: objectID)
+                    return object
+                })
+                
+            case .dictionaryResultType:
+                return resultsFromLocalStore.map({(result)->[String:Any] in
+                    var result = result as! [String:Any]
+                    result[SMStore.SMLocalStoreRecordIDAttributeName] = nil
+                    return result
+                })
+            case .managedObjectIDResultType:
+                return resultsFromLocalStore.map({(result)->NSManagedObjectID in
+                    let result = result as! NSManagedObjectID
+                    let object = self.backingMOC.registeredObject(for: result)!
+                    let recordID: String = object.value(forKey: SMStore.SMLocalStoreRecordIDAttributeName) as! String
+                    let entity = self.persistentStoreCoordinator?.managedObjectModel.entitiesByName[fetchRequest.entityName!]
+                    let objectID = self.newObjectID(for: entity!, referenceObject: recordID)
+                    return objectID
+                })
+            case .countResultType:
+                return [resultsFromLocalStore.count]
+            default:
+                break
+            }
+        }
+        return []
+    }
+    
+    func executeInResponseToCountFetchRequest(_ fetchRequest:NSFetchRequest<NSFetchRequestResult>,context:NSManagedObjectContext) throws ->[Int] {
+        let resultsFromLocalStore = try self.backingMOC.count(for:fetchRequest)
+        return [resultsFromLocalStore]
+    }
+    
+    // MARK : SaveChanges Request
+    fileprivate func executeInResponseToSaveChangesRequest(_ saveRequest:NSSaveChangesRequest,context:NSManagedObjectContext) throws -> Array<AnyObject> {
+        try self.deleteObjectsFromBackingStore(objectsToDelete: context.deletedObjects, mainContext: context)
+        try self.insertObjectsInBackingStore(objectsToInsert: context.insertedObjects, mainContext: context)
+        try self.updateObjectsInBackingStore(objectsToUpdate: context.updatedObjects)
+        
+        
+        try self.backingMOC.saveIfHasChanges()
+        if self.syncAutomatically {
+            self.triggerSync()
+        }
+        return []
+    }
+    
+    func objectIDForBackingObjectForEntity(_ entityName: String, withReferenceObject referenceObject: String?) throws -> NSManagedObjectID? {
+        if referenceObject == nil {
+            return nil
+        }
+        let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: entityName)
+        fetchRequest.resultType = NSFetchRequestResultType.managedObjectIDResultType
+        fetchRequest.fetchLimit = 1
+        fetchRequest.predicate = NSPredicate(format: "%K == %@", SMStore.SMLocalStoreRecordIDAttributeName,referenceObject!)
+        let results = try self.backingMOC.fetch(fetchRequest)
+        if !results.isEmpty {
+            return results.last as? NSManagedObjectID
+        }
+        return nil
+    }
+    
+    fileprivate func setRelationshipValuesForBackingObject(_ backingObject:NSManagedObject,sourceObject:NSManagedObject) throws -> Void {
+        for relationship in Array(sourceObject.entity.relationshipsByName.values) as [NSRelationshipDescription] {
+            if sourceObject.hasFault(forRelationshipNamed: relationship.name) || sourceObject.value(forKey: relationship.name) == nil {
+                continue
+            }
+            if relationship.isToMany  {
+                let relationshipValue: Set<NSObject> = sourceObject.value(forKey: relationship.name) as! Set<NSObject>
+                var backingRelationshipValue: Set<NSObject> = Set<NSObject>()
+                for relationshipObject in relationshipValue {
+                    let relationshipManagedObject: NSManagedObject = relationshipObject as! NSManagedObject
+                    if relationshipManagedObject.objectID.isTemporaryID == false {
+                        let referenceObject: String = self.referenceObject(for: relationshipManagedObject.objectID) as! String
+                        let backingRelationshipObjectID = try self.objectIDForBackingObjectForEntity(relationship.destinationEntity!.name!, withReferenceObject: referenceObject)
+                        if backingRelationshipObjectID != nil {
+                            let backingRelationshipObject = try backingObject.managedObjectContext?.existingObject(with: backingRelationshipObjectID!)
+                            backingRelationshipValue.insert(backingRelationshipObject!)
+                        }
+                    }
+                }
+                backingObject.setValue(backingRelationshipValue, forKey: relationship.name)
+            } else {
+                let relationshipValue: NSManagedObject = sourceObject.value(forKey: relationship.name) as! NSManagedObject
+                if relationshipValue.objectID.isTemporaryID == false {
+                    let referenceObject: String = self.referenceObject(for: relationshipValue.objectID) as! String
+                    let backingRelationshipObjectID = try self.objectIDForBackingObjectForEntity(relationship.destinationEntity!.name!, withReferenceObject: referenceObject)
+                    if backingRelationshipObjectID != nil {
+                        let backingRelationshipObject = try self.backingMOC.existingObject(with: backingRelationshipObjectID!)
+                        backingObject.setValue(backingRelationshipObject, forKey: relationship.name)
+                    }
+                }
+            }
+        }
+    }
+    
+    func insertObjectsInBackingStore(objectsToInsert objects:Set<NSObject>, mainContext: NSManagedObjectContext) throws -> Void {
+        let mobs = Array(objects) as! [NSManagedObject]
+        let sorted = SMObjectDependencyGraph(objects: mobs).sorted as! [NSManagedObject]
+        for object in sorted {
+            
+            let sourceObject: NSManagedObject = object
+            let managedObject:NSManagedObject = NSEntityDescription.insertNewObject(forEntityName: (sourceObject.entity.name)!, into: self.backingMOC) as NSManagedObject
+            let keys = Array(sourceObject.entity.attributesByName.keys)
+            let dictionary = sourceObject.dictionaryWithValues(forKeys: keys)
+            managedObject.setValuesForKeys(dictionary)
+            let referenceObject: String = self.referenceObject(for: sourceObject.objectID) as! String
+            managedObject.setValue(referenceObject, forKey: SMStore.SMLocalStoreRecordIDAttributeName)
+            mainContext.willChangeValue(forKey: "objectID")
+            try mainContext.obtainPermanentIDs(for: [sourceObject])
+            mainContext.didChangeValue(forKey: "objectID")
+            SMStoreChangeSetHandler.defaultHandler.createChangeSet(ForInsertedObjectRecordID: referenceObject, entityName: sourceObject.entity.name!, backingContext: self.backingMOC)
+            try self.setRelationshipValuesForBackingObject(managedObject, sourceObject: sourceObject)
+            // Don't save the MOC here: rolling up all the saves into a single one will prevent saving data in an inconsistent save
+            // All saves are now performed in 'executeInResponseToSaveChangesRequest()'
+        }
+    }
+    
+    fileprivate func deleteObjectsFromBackingStore(objectsToDelete objects: Set<NSObject>, mainContext: NSManagedObjectContext) throws -> Void {
+        let predicateObjectRecordIDKey = "objectRecordID"
+        let predicate: NSPredicate = NSPredicate(format: "%K == $objectRecordID", SMStore.SMLocalStoreRecordIDAttributeName)
+        for object in objects {
+            let sourceObject: NSManagedObject = object as! NSManagedObject
+            let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: sourceObject.entity.name!)
+            let recordID: String = self.referenceObject(for: sourceObject.objectID) as! String
+            fetchRequest.predicate = predicate.withSubstitutionVariables([predicateObjectRecordIDKey: recordID])
+            fetchRequest.fetchLimit = 1
+            let results = try self.backingMOC.fetch(fetchRequest)
+            if !results.isEmpty {
+                if let backingObject: NSManagedObject = results.last as? NSManagedObject {
+                    SMStoreChangeSetHandler.defaultHandler.createChangeSet(ForDeletedObjectRecordID: recordID, backingContext: self.backingMOC)
+                    self.backingMOC.delete(backingObject)
+                    // Don't save the MOC here: rolling up all the saves into a single one will prevent saving data in an inconsistent save
+                    // All saves are now performed in 'executeInResponseToSaveChangesRequest()'
+                }
+            }
+        }
+    }
+    
+    fileprivate func updateObjectsInBackingStore(objectsToUpdate objects: Set<NSObject>) throws -> Void {
+        let predicateObjectRecordIDKey = "objectRecordID"
+        let predicate: NSPredicate = NSPredicate(format: "%K == $objectRecordID", SMStore.SMLocalStoreRecordIDAttributeName)
+        for object in objects {
+            let sourceObject: NSManagedObject = object as! NSManagedObject
+            let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: sourceObject.entity.name!)
+            let recordID: String = self.referenceObject(for: sourceObject.objectID) as! String
+            fetchRequest.predicate = predicate.withSubstitutionVariables([predicateObjectRecordIDKey:recordID])
+            fetchRequest.fetchLimit = 1
+            let results = try self.backingMOC.fetch(fetchRequest)
+            if !results.isEmpty {
+                if let backingObject: NSManagedObject = results.last as? NSManagedObject {
+                    let keys = Array(self.persistentStoreCoordinator!.managedObjectModel.entitiesByName[sourceObject.entity.name!]!.attributesByName.keys)
+                    let sourceObjectValues = sourceObject.dictionaryWithValues(forKeys: keys)
+                    backingObject.setValuesForKeys(sourceObjectValues)
+                    SMStoreChangeSetHandler.defaultHandler.createChangeSet(ForUpdatedObject: backingObject, usingContext: self.backingMOC)
+                    try self.setRelationshipValuesForBackingObject(backingObject, sourceObject: sourceObject)
+                    // Don't save the MOC here: rolling up all the saves into a single one will prevent saving data in an inconsistent save
+                    // All saves are now performed in 'executeInResponseToSaveChangesRequest()'
+                }
+            }
+        }
+    }
 }
+

--- a/Sources/Classes/SMStoreChangeSetHandler.swift
+++ b/Sources/Classes/SMStoreChangeSetHandler.swift
@@ -124,6 +124,18 @@ class SMStoreChangeSetHandler {
         changeSet.setValue(entityName, forKey: SMStoreChangeSetHandler.SMLocalStoreEntityNameAttributeName)
         changeSet.setValue(NSNumber(value: SMLocalStoreRecordChangeType.recordInserted.rawValue as Int16), forKey: SMStoreChangeSetHandler.SMLocalStoreChangeTypeAttributeName)
     }
+  
+  func countOfChangeSet(backingContext: NSManagedObjectContext) -> Int {
+    let r = NSFetchRequest<NSFetchRequestResult>(entityName: SMStore.SMLocalStoreChangeSetEntityName)
+    do {
+      let c =   try backingContext.count(for: r)
+      VERBOSE("OK There are \(c) items ready for upload")
+      return c
+    } catch {
+      ERROR("ERROR fetching from \(SMStore.SMLocalStoreChangeSetEntityName): \(error)")
+      return -1
+    }
+  }
     
     func createChangeSet(ForUpdatedObject object: NSManagedObject, usingContext context: NSManagedObjectContext) {
         let changeSet = NSEntityDescription.insertNewObject(forEntityName: SMStore.SMLocalStoreChangeSetEntityName, into: context)
@@ -171,6 +183,8 @@ class SMStoreChangeSetHandler {
     
     func recordsForUpdatedObjects(backingContext context: NSManagedObjectContext) throws -> [CKRecord]? {
         let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: SMStore.SMLocalStoreChangeSetEntityName)
+      let r = try context.fetch(fetchRequest)
+      //print("Ok Found \(r.count) recordsForUpdatedObjects (ready for server upload)")
         fetchRequest.predicate = NSPredicate(format: "%K == %@ || %K == %@", SMStoreChangeSetHandler.SMLocalStoreChangeTypeAttributeName, NSNumber(value: SMLocalStoreRecordChangeType.recordInserted.rawValue as Int16), SMStoreChangeSetHandler.SMLocalStoreChangeTypeAttributeName, NSNumber(value: SMLocalStoreRecordChangeType.recordUpdated.rawValue as Int16))
         let results = try context.fetch(fetchRequest)
         var ckRecords: [CKRecord] = [CKRecord]()

--- a/Sources/Classes/SMStoreChangeSetHandler.swift
+++ b/Sources/Classes/SMStoreChangeSetHandler.swift
@@ -125,17 +125,11 @@ class SMStoreChangeSetHandler {
         changeSet.setValue(NSNumber(value: SMLocalStoreRecordChangeType.recordInserted.rawValue as Int16), forKey: SMStoreChangeSetHandler.SMLocalStoreChangeTypeAttributeName)
     }
   
-  func countOfChangeSet(backingContext: NSManagedObjectContext) -> Int {
-    let r = NSFetchRequest<NSFetchRequestResult>(entityName: SMStore.SMLocalStoreChangeSetEntityName)
-    do {
-      let c =   try backingContext.count(for: r)
-      VERBOSE("OK There are \(c) items ready for upload")
-      return c
-    } catch {
-      ERROR("ERROR fetching from \(SMStore.SMLocalStoreChangeSetEntityName): \(error)")
-      return -1
+    func countOfChangeSet(backingContext: NSManagedObjectContext) throws -> Int {
+        let r = NSFetchRequest<NSFetchRequestResult>(entityName: SMStore.SMLocalStoreChangeSetEntityName)
+        let c = try backingContext.count(for: r)
+        return c
     }
-  }
     
     func createChangeSet(ForUpdatedObject object: NSManagedObject, usingContext context: NSManagedObjectContext) {
         let changeSet = NSEntityDescription.insertNewObject(forEntityName: SMStore.SMLocalStoreChangeSetEntityName, into: context)
@@ -183,8 +177,6 @@ class SMStoreChangeSetHandler {
     
     func recordsForUpdatedObjects(backingContext context: NSManagedObjectContext) throws -> [CKRecord]? {
         let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: SMStore.SMLocalStoreChangeSetEntityName)
-      let r = try context.fetch(fetchRequest)
-      //print("Ok Found \(r.count) recordsForUpdatedObjects (ready for server upload)")
         fetchRequest.predicate = NSPredicate(format: "%K == %@ || %K == %@", SMStoreChangeSetHandler.SMLocalStoreChangeTypeAttributeName, NSNumber(value: SMLocalStoreRecordChangeType.recordInserted.rawValue as Int16), SMStoreChangeSetHandler.SMLocalStoreChangeTypeAttributeName, NSNumber(value: SMLocalStoreRecordChangeType.recordUpdated.rawValue as Int16))
         let results = try context.fetch(fetchRequest)
         var ckRecords: [CKRecord] = [CKRecord]()

--- a/Sources/Classes/SMStoreSyncOperation.swift
+++ b/Sources/Classes/SMStoreSyncOperation.swift
@@ -97,14 +97,13 @@ class SMStoreSyncOperation: Operation {
 
         self.localStoreMOC.persistentStoreCoordinator = self.persistentStoreCoordinator
         if let completionBlock = self.syncCompletionBlock {
+            NotificationCenter.default.removeObserver(self)
             do {
                 try self.performSync()
                 print("Sync Performed", terminator: "\n")
-                NotificationCenter.default.removeObserver(self)
                 completionBlock(nil)
             } catch let error as NSError {
                 print("Sync Performed with Error", terminator: "\n")
-                NotificationCenter.default.removeObserver(self)
                 completionBlock(error)
             }
         }


### PR DESCRIPTION
Apologies for the monster PR - I was pressed for time and had to quickly iterate using my own repository. I am happy breaking it down into more manageable chunks or spending the time to explain the changes in detail - just let me know how you want to handle if - if you want to handle it.

Here is the summary:
• Algorithmic improvements for dependency graph
• New timeout value for fetch operations so errors can be detected
• Callback option for triggerSync is critical for some applications. In particular when starting up the app it make sense to sync immediately and block any changes until the initial sync is complete
• Most importantly, this saves the `localMOC` atomically: it saves exactly once for every `save` performed by the app, instead of saving `localMOC` for every object inserted / updated etc...
.....Saving atomically this is important because partial `save()`'s will break data consistency in some circumstances (e.g. think of folders containing other folders: the dependency graph can't help because it detects a loop, and you have a 2-way relationship with one side having a non-optional rule - so the save will fail if you try to insert a subfolder before saving the parent)
• Adds a new `verifyCloudKitStoreExists` API that simply checks for the existence of an SMStore on iCloud without side-effects (the API uses a new operation `SMServerZoneLookupOperation`). This can be useful for migrate/don't migrate decisions.

Note that this modified version of Seam3 has been in production with one of my apps (filtering for users with actual data, I would estimate that it has been used by  ~400 users so far). No complains so far, so I am feeling pretty good about that the implementation is ok