### PR TITLE
Flexible logging added, multiple bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,31 @@ lazy var persistentContainer: NSPersistentContainer = {
         
     }()
 ```
+By default, logs will be written to `os_log`, but you can route log messages to your own class by extending `SMLogger`:
+```
+class WTVAppDelegate: SMLogDelegate {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        SMStore.logger = self
+    }
+    // MARK: SMLogDelegate
+    func log(_ message: @autoclosure() -> String, type: SMLogType) {
+        #if DEBUG
+        switch type {
+        case .debug:
+        print("Debug: \(message())")
+        case .info:
+        print("Info: \(message())")
+        case .error:
+        print("Error: \(message())")
+        case .fault:
+        print("Fault: \(message())")
+        case .defaultType:
+        print("Default: \(message())")
+        }
+        #endif
+    }
+}
+```
 You can access the `SMStore` instance using:
 ```
 self.smStore = container.persistentStoreCoordinator.persistentStores.first as? SMStore

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ lazy var persistentContainer: NSPersistentContainer = {
 ```
 By default, logs will be written to `os_log`, but you can route log messages to your own class by extending `SMLogger`:
 ```
-class WTVAppDelegate: SMLogDelegate {
+class AppDelegate: SMLogDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         SMStore.logger = self
     }

--- a/Sources/Classes/CKRecord+NSManagedObject.swift
+++ b/Sources/Classes/CKRecord+NSManagedObject.swift
@@ -70,15 +70,10 @@ extension CKRecord {
     }
     
     fileprivate func allCKReferencesAsManagedObjects(usingContext context: NSManagedObjectContext, forManagedObject managedObject: NSManagedObject) throws -> [String:AnyObject]? {
-        // TODO: Need to fix relationships. No relationships are being saved at the moment
         if let entity = context.persistentStoreCoordinator?.managedObjectModel.entitiesByName[self.recordType] {
             let referencesValuesDictionary = self.dictionaryWithValues(forKeys: self.allReferencesKeys(usingRelationshipsByNameFromEntity: entity.relationshipsByName))
             var managedObjectsDictionary: Dictionary<String,AnyObject> = Dictionary<String,AnyObject>()
             for (key,value) in referencesValuesDictionary {
-                /* if (value as? String) != nil && (value as! String) == SMStore.SMCloudRecordNilValue {
-                 managedObjectsDictionary[key] = SMStore.SMCloudRecordNilValue as AnyObject?
-                 continue
-                 }*/
                 if let relationshipDescription = entity.relationshipsByName[key] {
                     if let destinationEntity = relationshipDescription.destinationEntity {
                         if let name = destinationEntity.name  {

--- a/Sources/Classes/NSManagedObject+CKRecord.swift
+++ b/Sources/Classes/NSManagedObject+CKRecord.swift
@@ -110,7 +110,7 @@ extension NSManagedObject {
             returnAsset = CKAsset(fileURL: fileURL)
             
         } catch {
-            os_log("Error creating asset: %@", type: .error, error.localizedDescription)
+            SMStore.logger?.error("ERROR creating asset: \(error.localizedDescription)")
         }
         
         return returnAsset

--- a/Sources/Classes/NSManagedObjectContext+Helpers.swift
+++ b/Sources/Classes/NSManagedObjectContext+Helpers.swift
@@ -34,15 +34,15 @@ extension NSManagedObjectContext {
     
     func saveIfHasChanges() throws {
       var err: Error?
+      performAndWait {
         if self.hasChanges {
-          performAndWait {
-            do {
-              try self.save()
-            } catch {
-              err = error
-            }
+          do {
+            try self.save()
+          } catch {
+            err = error
           }
         }
+      }
       if err != nil {
         throw err!
       }

--- a/Sources/Classes/SMLogger.swift
+++ b/Sources/Classes/SMLogger.swift
@@ -1,0 +1,60 @@
+//
+//  SMLogger.swift
+//  WebVideoCast
+//
+//  Created by hugo on 11/7/18.
+//  Copyright © 2018 Swishly. All rights reserved.
+//
+
+import Foundation
+import os.log
+
+public enum SMLogType {
+  case defaultType
+  case info
+  case debug
+  case error
+  case fault
+}
+
+public protocol SMLogDelegate: class {
+  func log(_ message: @autoclosure() -> String, type: SMLogType)
+  func info(_ message: @autoclosure() -> String)
+  func debug(_ message: @autoclosure() -> String)
+  func error(_ message: @autoclosure() -> String)
+  func fault(_ message: @autoclosure() -> String)
+}
+
+extension SMLogDelegate {
+  func info(_ message: @autoclosure() -> String) {
+    self.log(message, type: .info)
+  }
+  func debug(_ message: @autoclosure() -> String) {
+    self.log(message, type: .debug)
+  }
+  func error(_ message: @autoclosure() -> String) {
+    self.log(message, type: .error)
+  }
+  func fault(_ message: @autoclosure() -> String) {
+    self.log(message, type: .fault)
+  }
+}
+
+class SMLogger: SMLogDelegate {
+  static let sharedInstance = SMLogger()
+  func log(_ message: @autoclosure() -> String, type: SMLogType = .defaultType) {
+    let messageTemplate: StaticString = "%{private}@"
+    switch type {
+    case .defaultType:
+        os_log(messageTemplate, message())
+    case .info:
+        os_log(messageTemplate, message()) // Use of unresolved identifier 'os_log_info' (Xcode10.1)??
+    case .debug:
+        os_log(messageTemplate, message()) // Use of unresolved identifier 'os_log_debug' ??
+    case .error:
+        os_log(messageTemplate, message()) // Use of unresolved identifier 'os_log_error' ??
+    case .fault:
+        os_log(messageTemplate, message()) // Use of unresolved identifier 'os_log_fault' ??
+    }
+  }
+}

--- a/Sources/Classes/SMObjectDependencyGraph.swift
+++ b/Sources/Classes/SMObjectDependencyGraph.swift
@@ -121,7 +121,7 @@ class SMObjectDependencyGraph {
                 // Same order as entities
                 return index2 > index1
             }
-            os_log("WARNING Entity '%@' or '%@' not referenced in sortedEntityNames (this should never happen)", type: .debug, o1.entityIdentifier, o2.entityIdentifier)
+            SMStore.logger?.error("WARNING Entity '\(o1.entityIdentifier)' or '\(o2.entityIdentifier)' not referenced in sortedEntityNames (this should never happen)")
             return false
         }
         return results
@@ -133,7 +133,7 @@ class SMObjectDependencyGraph {
             for dependency in dependencies {
                 var augmentedChain = chain
                 if chain.contains(dependency) {
-                    os_log("WARNING Loop Detected! Path %@ already contains '%@'", type: .debug, chain.joined(separator: ", "), dependency)
+                    SMStore.logger?.info("WARNING Loop Detected! Path '\(chain.joined(separator: ", "))' already contains '\(dependency)'")
                     chains.append(chain)
                 } else {
                     augmentedChain.append(dependency)

--- a/Sources/Classes/SMServerStoreSetupOperation.swift
+++ b/Sources/Classes/SMServerStoreSetupOperation.swift
@@ -51,11 +51,11 @@ class SMServerStoreSetupOperation:Operation {
         
         let fetchRecordZonesOperation = CKFetchRecordZonesOperation(recordZoneIDs: [zone.zoneID])
         if #available(iOS 11.0, tvOS 11.0, OSX 10.13, *) {
-          let config = CKOperation.Configuration()
-          config.timeoutIntervalForResource = 10.0
-          fetchRecordZonesOperation.configuration = config
+            let config = CKOperation.Configuration()
+            config.timeoutIntervalForResource = 10.0
+            fetchRecordZonesOperation.configuration = config
         } else if #available(iOS 10.0, tvOS 11.0, OSX 10.12, *) {
-          fetchRecordZonesOperation.timeoutIntervalForResource = 10.0
+            fetchRecordZonesOperation.timeoutIntervalForResource = 10.0
         }
         fetchRecordZonesOperation.database = self.database
         
@@ -76,11 +76,12 @@ class SMServerStoreSetupOperation:Operation {
                     modifyRecordZonesOperation.database = self.database
                     modifyRecordZonesOperation.modifyRecordZonesCompletionBlock = ({(savedRecordZones, deletedRecordZonesIDs, operationError) -> Void in
                         error = operationError
-                        
-                        if operationError == nil {
-                            customZoneCreated = true
-                            defaults.set(true, forKey: SMStore.SMStoreCloudStoreCustomZoneName)
+                        guard operationError == nil else {
+                            SMStore.logger?.error("ERROR Failed to modify record zone \(operationError!)")
+                            return
                         }
+                        customZoneCreated = true
+                        defaults.set(true, forKey: SMStore.SMStoreCloudStoreCustomZoneName)
                     })
                     operationQueue.addOperation(modifyRecordZonesOperation)
                 } else {
@@ -122,11 +123,13 @@ class SMServerStoreSetupOperation:Operation {
                         let subscriptionsOperation = CKModifySubscriptionsOperation(subscriptionsToSave: [subscription], subscriptionIDsToDelete: nil)
                         subscriptionsOperation.database = self.database
                         subscriptionsOperation.modifySubscriptionsCompletionBlock=({ (modified,created,operationError) -> Void in
-                            if operationError == nil {
-                                UserDefaults.standard.set(true, forKey: SMStore.SMStoreCloudStoreSubscriptionName)
-                                subscriptionCreated = true
-                            }
                             error = operationError
+                            guard operationError == nil else {
+                                SMStore.logger?.error("ERROR Failed to subscribe to Cloud Kit updates \(operationError!)")
+                                return
+                            }
+                            UserDefaults.standard.set(true, forKey: SMStore.SMStoreCloudStoreSubscriptionName)
+                            subscriptionCreated = true
                         })
                         operationQueue.addOperation(subscriptionsOperation)
                     } else {

--- a/Sources/Classes/SMServerTokenHandler.swift
+++ b/Sources/Classes/SMServerTokenHandler.swift
@@ -33,7 +33,7 @@ import CloudKit
 
 
 class SMServerTokenHandler {
-
+    
     static let SMStoreSyncOperationServerTokenKey = "SMStoreSyncOperationServerTokenKey"
     static let defaultHandler = SMServerTokenHandler()
     fileprivate var newToken: CKServerChangeToken?
@@ -41,13 +41,16 @@ class SMServerTokenHandler {
     func token() -> CKServerChangeToken? {
         if UserDefaults.standard.object(forKey: SMServerTokenHandler.SMStoreSyncOperationServerTokenKey) != nil {
             let fetchTokenKeyArchived = UserDefaults.standard.object(forKey: SMServerTokenHandler.SMStoreSyncOperationServerTokenKey) as! Data
-            return NSKeyedUnarchiver.unarchiveObject(with: fetchTokenKeyArchived) as? CKServerChangeToken
+            let token = NSKeyedUnarchiver.unarchiveObject(with: fetchTokenKeyArchived) as? CKServerChangeToken
+            SMStore.logger?.debug("OK Retrieved CKServerChangeToken from userDefault: \(token)")
+            return token
         }
         return nil
     }
     
     func save(serverChangeToken: CKServerChangeToken) {
         self.newToken = serverChangeToken
+        SMStore.logger?.debug("OK Saved CKServerChangeToken: \(serverChangeToken)")
     }
     
     func unCommittedToken() -> CKServerChangeToken? {
@@ -57,10 +60,13 @@ class SMServerTokenHandler {
     func commit() {
         if let newToken = self.newToken  {
             UserDefaults.standard.set(NSKeyedArchiver.archivedData(withRootObject: newToken), forKey: SMServerTokenHandler.SMStoreSyncOperationServerTokenKey)
+            UserDefaults.standard.synchronize()
+            SMStore.logger?.debug("OK Committed CKServerChangeToken to userDefault: \(newToken  )")
         }
     }
     
     func delete() {
         UserDefaults.standard.set(nil, forKey: SMServerTokenHandler.SMStoreSyncOperationServerTokenKey)
+        UserDefaults.standard.synchronize()
     }
 }

--- a/Sources/Classes/SMStoreSyncOperation.swift
+++ b/Sources/Classes/SMStoreSyncOperation.swift
@@ -357,11 +357,15 @@ class SMStoreSyncOperation: Operation {
         var deletedCKRecordIDs: [CKRecord.ID] = [CKRecord.ID]()
         fetchRecordChangesOperation.recordZoneFetchCompletionBlock = { recordZoneID, serverChangeToken, clientChangeTokenData, moreComing, recordZoneError in
             SMStore.logger?.debug("OK (sync operation) recordZoneFetchCompletionBlock called with serverChangeToken=\(serverChangeToken), clientChangeTokenData=\(clientChangeTokenData)")
-            SMServerTokenHandler.defaultHandler.save(serverChangeToken: serverChangeToken!)
+            if let token = serverChangeToken {
+                SMServerTokenHandler.defaultHandler.save(serverChangeToken: token)
+            }
         }
         fetchRecordChangesOperation.recordZoneChangeTokensUpdatedBlock = { recordZoneID, serverChangeToken, clientChangeTokenData in
             SMStore.logger?.debug("OK (sync operation) recordZoneChangeTokensUpdatedBlock called with serverChangeToken=\(serverChangeToken), clientChangeTokenData=\(clientChangeTokenData)")
-            SMServerTokenHandler.defaultHandler.save(serverChangeToken: serverChangeToken!)
+            if let token = serverChangeToken {
+                SMServerTokenHandler.defaultHandler.save(serverChangeToken: token)
+            }
         }
         fetchRecordChangesOperation.fetchRecordZoneChangesCompletionBlock = { error in
             if error != nil {

--- a/Sources/Classes/SMStoreSyncOperation.swift
+++ b/Sources/Classes/SMStoreSyncOperation.swift
@@ -80,42 +80,40 @@ class SMStoreSyncOperation: Operation {
     var syncConflictResolutionBlock: SMStore.SMStoreConflictResolutionBlock?
     
     init(persistentStoreCoordinator:NSPersistentStoreCoordinator?, entitiesToSync entities:[NSEntityDescription], conflictPolicy:SMSyncConflictResolutionPolicy = .serverRecordWins, database: CKDatabase?, backingMOC: NSManagedObjectContext) {
-      self.persistentStoreCoordinator = persistentStoreCoordinator
-      self.entities = entities
-      self.database = database
-      self.syncConflictPolicy = conflictPolicy
-      self.backingMOC = backingMOC
-      super.init()
+        self.persistentStoreCoordinator = persistentStoreCoordinator
+        self.entities = entities
+        self.database = database
+        self.syncConflictPolicy = conflictPolicy
+        self.backingMOC = backingMOC
+        super.init()
     }
     
     // MARK: Sync
     override func main() {
-        os_log("Cloud Sync Started", type: .info)
+        SMStore.logger?.info("Cloud Sync Started")
         self.operationQueue = OperationQueue()
         self.operationQueue.maxConcurrentOperationCount = 1
         self.localStoreMOC = NSManagedObjectContext(concurrencyType: NSManagedObjectContextConcurrencyType.privateQueueConcurrencyType)
         NotificationCenter.default.addObserver(self, selector: #selector(SMStoreSyncOperation.backingContextDidSave(notification:)), name: NSNotification.Name.NSManagedObjectContextDidSave, object: backingMOC)
-
+        
         self.localStoreMOC.persistentStoreCoordinator = self.persistentStoreCoordinator
         if let completionBlock = self.syncCompletionBlock {
             NotificationCenter.default.removeObserver(self)
             do {
                 try self.performSync()
-                os_log("Cloud Sync Performed", type: .info)
                 completionBlock(nil)
             } catch let error as NSError {
-                os_log("Cloud Sync Performed with Error", type: .error)
                 completionBlock(error)
             }
         }
-      
+        
     }
-  
-  @objc func backingContextDidSave(notification: Notification) {
-    self.localStoreMOC.performAndWait {
-      self.localStoreMOC.mergeChanges(fromContextDidSave: notification)
+    
+    @objc func backingContextDidSave(notification: Notification) {
+        self.localStoreMOC.performAndWait {
+            self.localStoreMOC.mergeChanges(fromContextDidSave: notification)
+        }
     }
-  }
     
     func performSync() throws {
         var localChangesInServerRepresentation = try self.localChangesInServerRepresentation()
@@ -141,14 +139,17 @@ class SMStoreSyncOperation: Operation {
             SMServerTokenHandler.defaultHandler.commit()
             try SMStoreChangeSetHandler.defaultHandler.removeAllQueuedChangeSets(backingContext: self.localStoreMOC!)
         } catch {
-            os_log("ERROR during performSync() %@", type: .error, error.localizedDescription)
+            SMStore.logger?.error("ERROR during performSync() \(error.localizedDescription)")
             #if DEBUG
             if let conflictList = (error as NSError).userInfo["conflictList"] as? [NSMergeConflict] {
                 for conflict in conflictList {
-                    print("\nconflict:")
-                    print("\nobjectSnapshot: \(conflict.objectSnapshot ?? [:])")
-                    print("\ncachedSnapshot: \(conflict.cachedSnapshot ?? [:])")
-                    print("\npersistedSnapshot: \(conflict.persistedSnapshot ?? [:])")
+                    let message = """
+                    conflict:
+                    objectSnapshot: \(conflict.objectSnapshot ?? [:])
+                    cachedSnapshot: \(conflict.cachedSnapshot ?? [:])
+                    persistedSnapshot: \(conflict.persistedSnapshot ?? [:])
+                    """
+                    SMStore.logger?.error(message)
                 }
             }
             #endif
@@ -158,7 +159,17 @@ class SMStoreSyncOperation: Operation {
     
     func fetchAndApplyServerChangesToLocalDatabase() throws {
         let returnValue = self.fetchRecordChangesFromServer()
-        try self.applyServerChangesToLocalDatabase(returnValue.insertedOrUpdatedCKRecords, deletedCKRecordIDs: returnValue.deletedRecordIDs)
+        var executeError: Error?
+        self.localStoreMOC.performAndWait {
+            do {
+                try self.applyServerChangesToLocalDatabase(returnValue.insertedOrUpdatedCKRecords, deletedCKRecordIDs: returnValue.deletedRecordIDs)
+            } catch {
+                executeError = error
+            }
+        }
+        if let error = executeError {
+            throw error
+        }
     }
     
     // MARK: Local Changes
@@ -189,29 +200,31 @@ class SMStoreSyncOperation: Operation {
                 changedRecords[recordName] = record
             }
         }
-        
+        SMStore.logger?.debug("Will attempt saving (insert/update) to the cloud \(changedRecords.count) CKRecords \(changedRecords.keys)")
+        SMStore.logger?.debug("Will attempt deleting from the cloud \(deletedCKRecordIDs?.count ?? 0) CKRecords \((deletedCKRecordIDs ?? []).map {$0.recordName})")
         let ckModifyRecordsOperation = CKModifyRecordsOperation(recordsToSave: Array(changedRecords.values), recordIDsToDelete: deletedCKRecordIDs)
         ckModifyRecordsOperation.database = self.database
         let savedRecords: [CKRecord] = [CKRecord]()
         var conflictedRecords = [SeamConflictedRecord]()
         ckModifyRecordsOperation.modifyRecordsCompletionBlock = ({(savedRecords,deletedRecordIDs,operationError)->Void in
             if operationError != nil {
+                var operationErrorWillbeHandled = false
                 if let error = operationError as? CKError {
                     if let recordErrors = error.userInfo[CKPartialErrorsByItemIDKey] as? [CKRecord.ID:CKError] {
                         for recordError in recordErrors.values {
                             if recordError.code != CKError.serverRecordChanged {
-                                os_log("Operation error:%@", type: .error, error.localizedDescription)
+                                operationErrorWillbeHandled = true
                             }
                         }
                     }
-                } else {
-                    print("Operation error \(operationError!)")
                 }
+                SMStore.logger?.error("Operation error: \(operationError!) (will be handled with conflict resolution=\(operationErrorWillbeHandled)")
             }
         })
         ckModifyRecordsOperation.perRecordCompletionBlock = ({(ckRecord,operationError)->Void in
             
             guard let error = operationError as? CKError else {
+                SMStore.logger?.debug("OK Completed CKRecord operation (change/insert or delete to the cloud) for \(ckRecord.recordID.recordName)")
                 return
             }
             
@@ -224,12 +237,17 @@ class SMStoreSyncOperation: Operation {
                 }
                 let conflict = SeamConflictedRecord(serverRecord: serverRecord, clientRecord: clientRecord, clientAncestorRecord: ancestorRecord)
                 conflictedRecords.append(conflict)
+            } else {
+                SMStore.logger?.error("ERROR CKRecord operation (change/insert or delete to the cloud) failed for \(ckRecord.recordID.recordName)\n\(error)\n\(error.userInfo)")
             }
         })
+        
         self.operationQueue.addOperation(ckModifyRecordsOperation)
         self.operationQueue.waitUntilAllOperationsAreFinished()
         guard conflictedRecords.isEmpty else {
-            throw SMSyncOperationError.conflictsDetected(conflictedRecords: conflictedRecords)
+            let conflict = SMSyncOperationError.conflictsDetected(conflictedRecords: conflictedRecords)
+            SMStore.logger?.info("OK Conflict while updating CKRecords in the cloud \n\(conflictedRecords)")
+            throw conflict
         }
         if !savedRecords.isEmpty {
             let recordIDSubstitution = "recordIDSubstitution"
@@ -265,7 +283,7 @@ class SMStoreSyncOperation: Operation {
                 
             case .clientRecordWins:
                 
-
+                
                 for key in serverRecord.allKeys() {
                     serverRecord[key] = clientRecord[key]
                 }
@@ -291,41 +309,76 @@ class SMStoreSyncOperation: Operation {
     
     func localChangesInServerRepresentation() throws -> (insertedOrUpdatedCKRecords:Array<CKRecord>?,deletedCKRecordIDs:Array<CKRecord.ID>?) {
         let changeSetHandler = SMStoreChangeSetHandler.defaultHandler
-        let insertedOrUpdatedCKRecords = try changeSetHandler.recordsForUpdatedObjects(backingContext: self.localStoreMOC!)
-        let deletedCKRecordIDs = try changeSetHandler.recordIDsForDeletedObjects(self.localStoreMOC!)
-        return (insertedOrUpdatedCKRecords,deletedCKRecordIDs)
+        var insertedOrUpdatedCKRecords: Array<CKRecord>?
+        var deletedCKRecordIDs: Array<CKRecord.ID>?
+        var executeError: Error?
+        self.localStoreMOC!.performAndWait {
+            do {
+                insertedOrUpdatedCKRecords = try changeSetHandler.recordsForUpdatedObjects(backingContext: self.localStoreMOC!)
+                deletedCKRecordIDs = try changeSetHandler.recordIDsForDeletedObjects(self.localStoreMOC!)
+            } catch {
+                executeError = error
+            }
+        }
+        if let error = executeError {
+            throw error
+        }
+        let insertedIds = insertedOrUpdatedCKRecords?.map {$0.recordID.recordName} ?? []
+        let deletedIds = deletedCKRecordIDs?.map {$0.recordName} ?? []
+        SMStore.logger?.debug("Local insert/update changes detected: \(insertedOrUpdatedCKRecords?.count ?? -1) insertedOrUpdated\n\(insertedIds)")
+        SMStore.logger?.debug("Local delete changes detected: \(deletedCKRecordIDs?.count ?? -1) deleted\n\(deletedIds)")
+        return (insertedOrUpdatedCKRecords: insertedOrUpdatedCKRecords, deletedCKRecordIDs: deletedCKRecordIDs)
     }
     
     func fetchRecordChangesFromServer() -> (insertedOrUpdatedCKRecords: Array<CKRecord>, deletedRecordIDs: Array<CKRecord.ID>) {
-        
         var syncOperationError: Error? = nil
         
         let token = SMServerTokenHandler.defaultHandler.token()
         let recordZoneID = CKRecordZone.ID(zoneName: SMStore.SMStoreCloudStoreCustomZoneName, ownerName: CKCurrentUserDefaultName)
+        SMStore.logger?.debug("OK Will fetch server changes with previousServerChangeToken=\(token)")
         let fetchRecordChangesOperation = CKFetchRecordZoneChangesOperation()
         fetchRecordChangesOperation.recordZoneIDs = [recordZoneID]
-        if #available(iOS 12.0, watchOS 5.0, macOS 10.14, tvOS 12.0, *) {
-            fetchRecordChangesOperation.configurationsByRecordZoneID?[recordZoneID] = CKFetchRecordZoneChangesOperation.ZoneConfiguration(previousServerChangeToken: token, resultsLimit: nil, desiredKeys: nil)
-        }
+        /* By Tifroz: the commented code below (fetchRecordChangesOperation.configurationsByRecordZoneID) doesn't work at all - at least on iOS12
+         1/ previousServerChangeToken does not seem to be taken into account
+         2/ seems to mess with zone subscriptions (in particular, delete notification 'recordWithIDWasDeletedBlock' does not get called
+        */
+        /*if #available(iOS 12.0, watchOS 5.0, macOS 10.14, tvOS 12.0, *) {
+         fetchRecordChangesOperation.configurationsByRecordZoneID?[recordZoneID] = CKFetchRecordZoneChangesOperation.ZoneConfiguration(previousServerChangeToken: token, resultsLimit: nil, desiredKeys: nil)
+         } else {
+        }*/
+        let options = CKFetchRecordZoneChangesOperation.ZoneOptions()
+        options.previousServerChangeToken = token
+        var optionsByRecordZoneID = [CKRecordZone.ID: CKFetchRecordZoneChangesOperation.ZoneOptions]()
+        optionsByRecordZoneID[recordZoneID] = options
+        fetchRecordChangesOperation.optionsByRecordZoneID = optionsByRecordZoneID
+
         fetchRecordChangesOperation.database = self.database
         var insertedOrUpdatedCKRecords: [CKRecord] = [CKRecord]()
         var deletedCKRecordIDs: [CKRecord.ID] = [CKRecord.ID]()
-        fetchRecordChangesOperation.recordZoneChangeTokensUpdatedBlock = { recordZoneID, serverChangeToken, clientChangeTokenData in
+        fetchRecordChangesOperation.recordZoneFetchCompletionBlock = { recordZoneID, serverChangeToken, clientChangeTokenData, moreComing, recordZoneError in
+            SMStore.logger?.debug("OK (sync operation) recordZoneFetchCompletionBlock called with serverChangeToken=\(serverChangeToken), clientChangeTokenData=\(clientChangeTokenData)")
             SMServerTokenHandler.defaultHandler.save(serverChangeToken: serverChangeToken!)
-            SMServerTokenHandler.defaultHandler.commit()
+        }
+        fetchRecordChangesOperation.recordZoneChangeTokensUpdatedBlock = { recordZoneID, serverChangeToken, clientChangeTokenData in
+            SMStore.logger?.debug("OK (sync operation) recordZoneChangeTokensUpdatedBlock called with serverChangeToken=\(serverChangeToken), clientChangeTokenData=\(clientChangeTokenData)")
+            SMServerTokenHandler.defaultHandler.save(serverChangeToken: serverChangeToken!)
         }
         fetchRecordChangesOperation.fetchRecordZoneChangesCompletionBlock = { error in
             if error != nil {
                 syncOperationError = error
+            } else {
+                SMStore.logger?.info("OK (sync operation) fetchRecordZoneChangesCompletionBlock returned with no error")
             }
         }
         
         fetchRecordChangesOperation.recordChangedBlock = { record in
             let ckRecord = record as CKRecord
             insertedOrUpdatedCKRecords.append(ckRecord)
+            SMStore.logger?.debug("OK (sync operation) recordChangedBlock called for record: \(ckRecord.recordID.recordName)")
         }
         fetchRecordChangesOperation.recordWithIDWasDeletedBlock = { recordID, recordType in
             deletedCKRecordIDs.append(recordID as CKRecord.ID)
+            SMStore.logger?.debug("OK (sync operation) recordWithIDWasDeletedBlock called for record: \(recordID.recordName)")
         }
         self.operationQueue!.addOperation(fetchRecordChangesOperation)
         self.operationQueue!.waitUntilAllOperationsAreFinished()
@@ -367,6 +420,7 @@ class SMStoreSyncOperation: Operation {
                 self.operationQueue.addOperation(fetchRecordsOperation)
                 self.operationQueue.waitUntilAllOperationsAreFinished()
             }
+            
         } else {
             if let error = syncOperationError as? CKError {
                 if error.code == .changeTokenExpired {
@@ -375,32 +429,38 @@ class SMStoreSyncOperation: Operation {
                 }
             }
         }
+        let insertedIds = insertedOrUpdatedCKRecords.map {$0.recordID.recordName}
+        let deletedIds = deletedCKRecordIDs.map {$0.recordName}
+        SMStore.logger?.debug("OK (sync operation) cloud changes detected: \(insertedOrUpdatedCKRecords.count) insertedOrUpdated\n\(insertedIds)")
+        SMStore.logger?.debug("OK (sync operation) cloud changes detected: \(deletedCKRecordIDs.count) deleted\n\(deletedIds)")
+        
+        SMServerTokenHandler.defaultHandler.commit()
         return (insertedOrUpdatedCKRecords, deletedCKRecordIDs)
     }
     
     func insertOrUpdateManagedObjects(fromCKRecords ckRecords:Array<CKRecord>, retryCount: Int = 0) throws {
         var deferredRecords = [CKRecord]()
-      
-      // Sorting records using the dependancy graph can cut down dramatically ...
-      //  ...the number of deferred attempts necessary (see deferredRecords)
-      let sorted = SMObjectDependencyGraph(records: ckRecords, for: entities).sorted as! [CKRecord]
-      for record in sorted {
-          do {
-            let _ = try record.createOrUpdateManagedObjectFromRecord(usingContext: self.localStoreMOC!)
-          } catch SMStoreError.missingRelatedObject {
-            deferredRecords.append(record)
-          }
-        // Don't save the MOC here: rolling up all the saves into a single one will prevent saving data in an inconsistent save
-        // All saves are now performed in 'applyServerChangesToLocalDatabase()'
-      }
-      
-      if !deferredRecords.isEmpty {
-          if retryCount < self.RETRYLIMIT  {
-              try self.insertOrUpdateManagedObjects(fromCKRecords: deferredRecords, retryCount:retryCount+1)
-          } else {
-              throw SMSyncOperationError.missingReferences(referringRcords: deferredRecords)
-          }
-      }
+        
+        // Sorting records using the dependancy graph can cut down dramatically ...
+        //  ...the number of deferred attempts necessary (see deferredRecords)
+        let sorted = SMObjectDependencyGraph(records: ckRecords, for: entities).sorted as! [CKRecord]
+        for record in sorted {
+            do {
+                let managedObj = try record.createOrUpdateManagedObjectFromRecord(usingContext: self.localStoreMOC!)
+            } catch SMStoreError.missingRelatedObject {
+                deferredRecords.append(record)
+            }
+            // Don't save the MOC here: rolling up all the saves into a single one will prevent saving data in an inconsistent save
+            // All saves are now performed in 'applyServerChangesToLocalDatabase()'
+        }
+        
+        if !deferredRecords.isEmpty {
+            if retryCount < self.RETRYLIMIT  {
+                try self.insertOrUpdateManagedObjects(fromCKRecords: deferredRecords, retryCount:retryCount+1)
+            } else {
+                throw SMSyncOperationError.missingReferences(referringRcords: deferredRecords)
+            }
+        }
     }
     
     func deleteManagedObjects(fromCKRecordIDs ckRecordIDs:Array<CKRecord.ID>) throws {
@@ -415,6 +475,8 @@ class SMStoreSyncOperation: Operation {
             }
             for name in entityNames {
                 let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: name as String)
+                //fetchRequest.predicate = NSPredicate.
+                let all = try self.localStoreMOC.fetch(fetchRequest) as! [NSManagedObject]
                 fetchRequest.predicate = predicate.withSubstitutionVariables(["ckRecordIDs":ckRecordIDStrings])
                 let results = try self.localStoreMOC.fetch(fetchRequest)
                 if !results.isEmpty {


### PR DESCRIPTION
- Added flexible logging (see SMLogger, README)
- Bugs fixes
1. Refresh NSManagedObjectContexts _after_ saving the context
2. Wrapped all core data call in context.perform {} to avoid issues with concurrent access (crashes)
3. Fixed multiple issues with previousServerChangeToken, subscriptions that caused very inefficient sync, and unwanted behavior (delete notifications not called) - see SMStoreSyncOperation for commented out code