### PR TITLE
Fix for occasional crash

### DIFF
--- a/Sources/Classes/SMStore.swift
+++ b/Sources/Classes/SMStore.swift
@@ -959,7 +959,7 @@ open class SMStore: NSIncrementalStore {
             case .managedObjectIDResultType:
                 return resultsFromLocalStore.map({(result)->NSManagedObjectID in
                     let result = result as! NSManagedObjectID
-                    let object = self.backingMOC.registeredObject(for: result)!
+                    let object = self.backingMOC.object(with: result)
                     let recordID: String = object.value(forKey: SMStore.SMLocalStoreRecordIDAttributeName) as! String
                     let entity = self.persistentStoreCoordinator?.managedObjectModel.entitiesByName[fetchRequest.entityName!]
                     let objectID = self.newObjectID(for: entity!, referenceObject: recordID)


### PR DESCRIPTION
According the doc, [fetch'ed()](https://developer.apple.com/documentation/coredata/nsmanagedobjectcontext/1506672-fetch) objects are supposed to be register with the context and therefore be immediately available via [registeredObject(for:)](https://developer.apple.com/documentation/coredata/nsmanagedobjectcontext/1506789-registeredobject), but this occasionally fails in my app under very specific circumstances.

[object(with:)](https://developer.apple.com/documentation/coredata/nsmanagedobjectcontext/1506197-object) essentially does the same but will refetch from the persistent store when the object isn't registered. So I think it is a safe replacement, and it fixes the crashes in my app.